### PR TITLE
check if supported mod is active

### DIFF
--- a/media/lua/client/Mod Support/AdditionalBooks2_Items.lua
+++ b/media/lua/client/Mod Support/AdditionalBooks2_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --ADDITIONALBOOKS2
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2209099061
+if getActivatedMods():contains("AdditionalBooks2") then
 --Literature
 TweakItem("AdditionalBooks2.BookAiming1","DisplayCategory","LitS");
 TweakItem("AdditionalBooks2.BookAiming2","DisplayCategory","LitS");
@@ -67,3 +69,4 @@ TweakItem("AdditionalBooks2.BookLightfooted2","DisplayCategory","LitS");
 TweakItem("AdditionalBooks2.BookLightfooted3","DisplayCategory","LitS");
 TweakItem("AdditionalBooks2.BookLightfooted4","DisplayCategory","LitS");
 TweakItem("AdditionalBooks2.BookLightfooted5","DisplayCategory","LitS");
+end

--- a/media/lua/client/Mod Support/AllAmericanApocalypse_Items.lua
+++ b/media/lua/client/Mod Support/AllAmericanApocalypse_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --AllAmericanApocolypse
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2026187681
+if getActivatedMods():contains("AAApoc") then
 TweakItem("TPaste.TPasteBSoda","DisplayCategory","Cooking");
 TweakItem("TPaste.TPasteBSodaEmpty","DisplayCategory","Junk");
 TweakItem("AAApoc.AAAMeatGrinder","DisplayCategory","Cooking");
@@ -192,3 +194,4 @@ TweakItem("AAApoc.AAAToastFJam","DisplayCategory","FoodP");
 TweakItem("AAApoc.AAAToastMarmalade","DisplayCategory","FoodP");
 TweakItem("AAApoc.AAAToastButterFJam","DisplayCategory","FoodP");
 TweakItem("AAApoc.AAAToastButterMarmalade","DisplayCategory","FoodP");
+end

--- a/media/lua/client/Mod Support/AllSkillBooks_Items.lua
+++ b/media/lua/client/Mod Support/AllSkillBooks_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --AllSkillBooks
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2699202565
+if getActivatedMods():contains("AllSkillBooks") then
 TweakItem("AllSkillBooks.BookFitness1","DisplayCategory","LitS");
 TweakItem("AllSkillBooks.BookFitness2","DisplayCategory","LitS");
 TweakItem("AllSkillBooks.BookFitness3","DisplayCategory","LitS");
@@ -76,3 +78,4 @@ TweakItem("AllSkillBooks.BookReloading2","DisplayCategory","LitS");
 TweakItem("AllSkillBooks.BookReloading3","DisplayCategory","LitS");
 TweakItem("AllSkillBooks.BookReloading4","DisplayCategory","LitS");
 TweakItem("AllSkillBooks.BookReloading5","DisplayCategory","LitS");
+end

--- a/media/lua/client/Mod Support/Ammocraft_Items.lua
+++ b/media/lua/client/Mod Support/Ammocraft_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --AMMOCRAFT
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2245813444
+if getActivatedMods():contains("ammocraft") or getActivatedMods():contains("ammocraftfirearms") then
 --Crafting Ammo
 TweakItem("Base.Bullets9mm_casingbox","DisplayCategory","CraftAmmo");
 TweakItem("Base.Bullets45_casingbox","DisplayCategory","CraftAmmo");
@@ -81,3 +83,4 @@ TweakItem("Base.GunnutBible","DisplayCategory","LitR");
 --Tool
 TweakItem("Base.Reloadingpress","DisplayCategory","Tool");
 TweakItem("Base.Pliers","DisplayCategory","Tool");
+end

--- a/media/lua/client/Mod Support/Arsenal-Brita_Items.lua
+++ b/media/lua/client/Mod Support/Arsenal-Brita_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --ARSENAL
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2297098490
+if getActivatedMods():contains("Arsenal(26)GunFighter") then
 TweakItem("Base.AmmoCan30_22","DisplayCategory","Ammo");
 TweakItem("Base.AmmoCan30_57","DisplayCategory","Ammo");
 TweakItem("Base.AmmoCan30_380","DisplayCategory","Ammo");
@@ -1024,7 +1026,11 @@ TweakItem("Base.Suppressor_PBS1_Rifle","DisplayCategory","WepPart");
 TweakItem("Base.Suppressor_PBS4_Rifle","DisplayCategory","WepPart");
 TweakItem("Base.Suppressor_ROME_BMG","DisplayCategory","WepPart");
 TweakItem("Base.Suppressor_SOCOM_Pistol","DisplayCategory","WepPart");
+end
+
 --BritaWeaponPack
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2200148440
+if getActivatedMods():contains("Brita") then
 TweakItem("Base.Bolt_Bear","DisplayCategory","WepAmmo");
 TweakItem("Base.Bolt_Bear_Pack","DisplayCategory","WepAmmo");
 TweakItem("Base.BGMachete","DisplayCategory","WepMelee");
@@ -1040,7 +1046,11 @@ TweakItem("Base.Tactical_Axe","DisplayCategory","WepMelee");
 TweakItem("Base.Tactical_Sickle","DisplayCategory","WepMelee");
 TweakItem("Base.Cleaning","DisplayCategory","Tool");
 TweakItem("Base.WD","DisplayCategory","Tool");
+end
+
 --BritaArmor
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2460154811
+if getActivatedMods():contains("Brita_2") then
 TweakItem("Base.Armor_Defender","DisplayCategory","Cloth");
 TweakItem("Base.Bag_Plate_Carrier","DisplayCategory","Cloth");
 TweakItem("Base.Armor_6B13","DisplayCategory","Cloth");
@@ -1188,3 +1198,4 @@ TweakItem("Base.Rabbit_Suit","DisplayCategory","Cloth");
 TweakItem("Base.Hat_Rabbit","DisplayCategory","Cloth");
 TweakItem("Base.Bag_Smersh_Vest","DisplayCategory","ClothA");
 TweakItem("Base.Bag_Smersh_Vest_Loose","DisplayCategory","ClothA");
+end

--- a/media/lua/client/Mod Support/AuthenticZ_Items.lua
+++ b/media/lua/client/Mod Support/AuthenticZ_Items.lua
@@ -1,6 +1,9 @@
 require("ItemTweaker_Copy_CC");
 
 --AuthenticZ
+if getActivatedMods():contains("AuthenticZBackpacks+") 
+or getActivatedMods():contains("Authentic Z - Current") 
+or getActivatedMods():contains("AuthenticZLite") then
 TweakItem("AuthenticZClothing.FlareGun","DisplayCategory","WepFire");
 TweakItem("AuthenticZClothing.Flare12GaugeShot","DisplayCategory","Ammo");
 TweakItem("AuthenticZClothing.PZAZ_HitList","DisplayCategory","LitW");
@@ -810,3 +813,4 @@ TweakItem("AuthenticZClothing.WeddingDressBlue","DisplayCategory","Cloth");
 TweakItem("AuthenticZClothing.WeddingDressPink","DisplayCategory","Cloth");
 TweakItem("AuthenticZClothing.Fat01_AmmoStrap","DisplayCategory","WepPart");
 TweakItem("AuthenticZClothing.Fat01_Vest_HighViz","DisplayCategory","Cloth");
+end

--- a/media/lua/client/Mod Support/ClothesBox_Items.lua
+++ b/media/lua/client/Mod Support/ClothesBox_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --ClothesBox
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2507488373
+if getActivatedMods():contains("2507488373") then
 TweakItem("Base.	CAPARM_1	","DisplayCategory","	Cloth	");
 TweakItem("Base.	CAPARM_2	","DisplayCategory","	Cloth	");
 TweakItem("Base.	CAPARM_3	","DisplayCategory","	Cloth	");
@@ -108,3 +110,4 @@ TweakItem("Base.	Trousers_CamoUrban2	","DisplayCategory","	Cloth	");
 TweakItem("Base.	Waterproof	","DisplayCategory","	Cloth	");
 TweakItem("Base.	Kurtk_3	","DisplayCategory","	Cloth	");
 TweakItem("Base.	KOMB	","DisplayCategory","	Cloth	");
+end

--- a/media/lua/client/Mod Support/CornerStore_Items.lua
+++ b/media/lua/client/Mod Support/CornerStore_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --CornerStoreCandiesAndSodas
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2412050672
+if getActivatedMods():contains("2412050672") then
 TweakItem("CCS.Pepso","DisplayCategory","FoodB");
 TweakItem("CCS.DrPepppa","DisplayCategory","FoodB");
 TweakItem("CCS.FantoOrange","DisplayCategory","FoodB");
@@ -64,3 +66,4 @@ TweakItem("CCS.HateradeYl","DisplayCategory","FoodB");
 TweakItem("CCS.minichugBL","DisplayCategory","FoodB");
 TweakItem("CCS.minichugPi","DisplayCategory","FoodB");
 TweakItem("CCS.minichugOr","DisplayCategory","FoodB");
+end

--- a/media/lua/client/Mod Support/DJVirus_Items.lua
+++ b/media/lua/client/Mod Support/DJVirus_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --BetterBelts
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2127583399
+if getActivatedMods():contains("Better Belts") then
 TweakItem("Base.Belt3","DisplayCategory","Cloth");
 TweakItem("Base.Belt4","DisplayCategory","Cloth");
 TweakItem("Base.HolsterSimpleL","DisplayCategory","ClothA");
@@ -24,7 +26,11 @@ TweakItem("Base.HookedWaterBottleEmptyPurple","DisplayCategory","Container");
 TweakItem("Base.HookedWaterBottleFullPurple","DisplayCategory","FoodB");
 TweakItem("Base.HookedWaterBottleEmptyRed","DisplayCategory","Container");
 TweakItem("Base.HookedWaterBottleFullRed","DisplayCategory","FoodB");
+end
+
 --ScrapArmor
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2658619264
+if getActivatedMods():contains("ScrapArmor(new version)") then
 TweakItem("Base.Rucksack","DisplayCategory","ClothB");
 TweakItem("Base.SwordSheath","DisplayCategory","ClothA");
 TweakItem("Base.ScrapLegPouchL","DisplayCategory","ClothA");
@@ -88,7 +94,11 @@ TweakItem("Base.ScrapVest","DisplayCategory","Cloth");
 TweakItem("Base.ScrapVestPlated","DisplayCategory","Cloth");
 TweakItem("Base.ScrapVestSign","DisplayCategory","Cloth");
 TweakItem("Base.ScrapVestStudded","DisplayCategory","Cloth");
+end
+
 --ScrapGuns
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2125659488
+if getActivatedMods():contains("ScrapGuns(new version)") then
 TweakItem("SGuns.ScrapGunMag1","DisplayCategory","LitR");
 TweakItem("SGuns.ScrapGunMag2","DisplayCategory","LitR");
 TweakItem("SGuns.ScrapGunMag3","DisplayCategory","LitR");
@@ -125,7 +135,11 @@ TweakItem("SGuns.ScrapBullets","DisplayCategory","Ammo");
 TweakItem("SGuns.ScrapBBox","DisplayCategory","Ammo");
 TweakItem("SGuns.ScrapGatling","DisplayCategory","WepFire");
 TweakItem("SGuns.GatlingBoxMagazine","DisplayCategory","WepAmmoMag");
+end
+
 --ScrapWeapons
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2122265954
+if getActivatedMods():contains("ScrapWeapons(new version)") then
 TweakItem("SWeapons.WeaponMag1","DisplayCategory","LitR");
 TweakItem("SWeapons.WeaponMag2","DisplayCategory","LitR");
 TweakItem("SWeapons.WeaponMag3","DisplayCategory","LitR");
@@ -173,7 +187,11 @@ TweakItem("SWeapons.SpearScrapShiv","DisplayCategory","WepMelee");
 TweakItem("SWeapons.SpearScrapMachete","DisplayCategory","WepMelee");
 TweakItem("SWeapons.SpearSalvaged","DisplayCategory","WepMelee");
 TweakItem("SWeapons.ScrapSpear","DisplayCategory","WepMelee");
+end
+
 --TheWorkshop
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2680473910
+if getActivatedMods():contains("TheWorkshop(new version)") then
 TweakItem("Base.Toolbelt","DisplayCategory","ClothA");
 TweakItem("Base.NailGun","DisplayCategory","Tool");
 TweakItem("Base.NailGunMagazine","DisplayCategory","Tool");
@@ -212,3 +230,4 @@ TweakItem("TW.HoeHead","DisplayCategory","Craft");
 TweakItem("TW.PickaxeHead","DisplayCategory","Craft");
 TweakItem("TW.RakeHead","DisplayCategory","Craft");
 TweakItem("TW.ForkHead","DisplayCategory","Craft");
+end

--- a/media/lua/client/Mod Support/DLTS_Items.lua
+++ b/media/lua/client/Mod Support/DLTS_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --DLTS
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1962914415
+if getActivatedMods():contains("DLTS") then
 --Container
 TweakItem("DLTS.LTSDryingMeatWet","DisplayCategory","Container");
 TweakItem("DLTS.LTSDryingMeat","DisplayCategory","Container");
@@ -170,3 +172,4 @@ TweakItem("DLTS.LTSWoodBurner","DisplayCategory","Tool");
 TweakItem("DLTS.LTSBatHardened","DisplayCategory","WepMelee");
 TweakItem("DLTS.LTSBatBarbed","DisplayCategory","WepMelee");
 TweakItem("DLTS.LTSBatSpiked","DisplayCategory","WepMelee");
+end

--- a/media/lua/client/Mod Support/Dylans_Items.lua
+++ b/media/lua/client/Mod Support/Dylans_Items.lua
@@ -1,10 +1,15 @@
 require("ItemTweaker_Copy_CC");
 
 --NewEkron
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2712480036
+if getActivatedMods():contains("TheWorkshop(new version)") then
 TweakItem("Base.TheBong","DisplayCategory","WepMelee");
 TweakItem("Base.Rusty","DisplayCategory","WepFire");
+end
 
 --Pitstop
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2597946327
+if getActivatedMods():contains("Pitstop") or getActivatedMods():contains("PitstopLegacy") then
 TweakItem("Base.AirMags","DisplayCategory","Cloth");
 TweakItem("Base.AlienBackPack","DisplayCategory","ClothB");
 TweakItem("Base.AlienCap","DisplayCategory","Cloth");
@@ -61,3 +66,4 @@ TweakItem("Base.GhostTrap","DisplayCategory","WepMelee");
 TweakItem("Base.EnergySword","DisplayCategory","WepMelee");
 TweakItem("Base.DjackzVinyl","DisplayCategory","WepMelee");
 TweakItem("Base.FutureShotgun","DisplayCategory","WepFire");
+end

--- a/media/lua/client/Mod Support/EasyPacking_Items.lua
+++ b/media/lua/client/Mod Support/EasyPacking_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --EASYPACKING
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2438225189
+if getActivatedMods():contains("EasyPacking") or getActivatedMods():contains("EasyPackingHC") then
 TweakItem("Base.Soap2","DisplayCategory","Cleaning");
 TweakItem("GidOrganized.OS30pkAntibiotics","DisplayCategory","Medical");
 TweakItem("GidOrganized.OS12pkAdhesiveBandages","DisplayCategory","Medical");
@@ -140,4 +142,4 @@ TweakItem("Packing.pkMetalwork","DisplayCategory","LitS");
 TweakItem("Packing.pkTrapping","DisplayCategory","LitS");
 TweakItem("Packing.10pkBook","DisplayCategory","LitE");
 TweakItem("Packing.5pkBook","DisplayCategory","LitE");
-
+end

--- a/media/lua/client/Mod Support/EggonsAllDoors_Items.lua
+++ b/media/lua/client/Mod Support/EggonsAllDoors_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --AllDoorsAreYours
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2733027635
+if getActivatedMods():contains("eggonsAllDoorsAreYours") then
 TweakItem("EADAY.CarpentryDoor1","DisplayCategory","CraftCarp");
 TweakItem("EADAY.CarpentryDoor2","DisplayCategory","CraftCarp");
 TweakItem("EADAY.CarpentryDoor3","DisplayCategory","CraftCarp");
@@ -56,3 +58,4 @@ TweakItem("EADAY.SplitGlassDoor_PizzaWhirled","DisplayCategory","CraftCarp");
 TweakItem("EADAY.ToiletCabinDoor_Blue","DisplayCategory","CraftCarp");
 TweakItem("EADAY.ToiletCabinDoor_Rose","DisplayCategory","CraftCarp");
 TweakItem("EADAY.UnknownDoor","DisplayCategory","CraftCarp");
+end

--- a/media/lua/client/Mod Support/ImmersiveMedicine_Items.lua
+++ b/media/lua/client/Mod Support/ImmersiveMedicine_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --ImmersiveMedicine
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2709866494
+if getActivatedMods():contains("iMeds") then
 --CLOTHING
 TweakItem("iMeds.BloodPressureMonitorLeft","DisplayCategory","Medical");
 TweakItem("iMeds.BloodPressureMonitorRight","DisplayCategory","Medical");
@@ -62,3 +64,4 @@ TweakItem("iMeds.NeedlePack","DisplayCategory","Medical");
 TweakItem("iMeds.Needle","DisplayCategory","Medical");
 TweakItem("iMeds.SyringeWithNeedle","DisplayCategory","Medical");
 TweakItem("iMeds.FullSyringeWithNeedle","DisplayCategory","Medical");
+end

--- a/media/lua/client/Mod Support/JiggasGreenFireMod_Items.lua
+++ b/media/lua/client/Mod Support/JiggasGreenFireMod_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --JIGGASGREENFIREMOD
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1703604612
+if getActivatedMods():contains("jiggasGreenfireMod") or getActivatedMods():contains("jiggasAddictionMod") then
 --Drugs
 TweakItem("Greenfire.FreshUnCanna","DisplayCategory","Drugs");
 TweakItem("Greenfire.FreshTCanna","DisplayCategory","Drugs");
@@ -113,3 +115,4 @@ TweakItem("Greenfire.TobaccoPipe","DisplayCategory","Drugs");
 TweakItem("Greenfire.TobaccoSeed","DisplayCategory","SurFarm");
 TweakItem("Greenfire.TobaccoBagSeed","DisplayCategory","SurFarm");
 TweakItem("Greenfire.PipeTobaccoBag","DisplayCategory","Drugs");
+end

--- a/media/lua/client/Mod Support/KCMcrossbow_Items.lua
+++ b/media/lua/client/Mod Support/KCMcrossbow_Items.lua
@@ -1,6 +1,9 @@
 require("ItemTweaker_Copy_CC");
 
 --KCMCROSSBOW
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2205190407
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2572385719
+if getActivatedMods():contains("TKCM") or getActivatedMods():contains("Remastered Kitsune's Crossbow Mod") then
 TweakItem("KCMweapons.KCM_Flax","DisplayCategory","Craft");
 TweakItem("KCMweapons.CrossbowBoltShaft","DisplayCategory","Craft");
 TweakItem("KCMweapons.CrossbowBoltParts","DisplayCategory","Craft");
@@ -35,3 +38,4 @@ TweakItem("KCMweapons.ShortShaft","DisplayCategory","Craft");
 TweakItem("KCMweapons.LongShaft","DisplayCategory","Craft");
 TweakItem("KCMweapons.CrossbowBoltHead","DisplayCategory","Craft");
 TweakItem("KCMweapons.CrossbowBoltFletching","DisplayCategory","Craft");
+end

--- a/media/lua/client/Mod Support/KI5_Items.lua
+++ b/media/lua/client/Mod Support/KI5_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --59Meteor
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2772575623
+if getActivatedMods():contains("59meteor") or getActivatedMods():contains("ECTO1") then
 TweakItem("Base.ECTO1tire2_Item","DisplayCategory","Mechanics");
 TweakItem("Base.ECTO1tire1_Item","DisplayCategory","Mechanics");
 TweakItem("Base.ECTO1Trunk2","DisplayCategory","Mechanics");
@@ -24,13 +26,21 @@ TweakItem("Base.ECTO1DefaultInterior2","DisplayCategory","Mechanics");
 TweakItem("Base.ECTO1Windshield2","DisplayCategory","Mechanics");
 TweakItem("Base.ECTO1RearWindshield2","DisplayCategory","Mechanics");
 TweakItem("Base.ECTO1SideWindow2","DisplayCategory","Mechanics");
+end
+
 --67Commando
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2478247379
+if getActivatedMods():contains("67commando") then
 TweakItem("Base.V100Tire2","DisplayCategory","Mechanics");
 TweakItem("Base.FrontLeftV100Door2","DisplayCategory","Mechanics");
 TweakItem("Base.FrontRightV100Door2","DisplayCategory","Mechanics");
 TweakItem("Base.RearV100Door2","DisplayCategory","Mechanics");
 TweakItem("Base.V100Window2","DisplayCategory","Mechanics");
+end
+
 --74amgeneralM151A2
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2785549133
+if getActivatedMods():contains("74amgeneralM151A2") then
 TweakItem("Base.V100Tire2","DisplayCategory","Mechanics");
 TweakItem("Base.V102Tire2","DisplayCategory","Mechanics");
 TweakItem("Base.M151A2Trunk2","DisplayCategory","Mechanics");
@@ -50,7 +60,11 @@ TweakItem("Base.M151A2WindshieldArmor1_Item","DisplayCategory","Mechanics");
 TweakItem("Base.M151A2CabArmor1_Item","DisplayCategory","Mechanics");
 TweakItem("Base.M151A2BarrierLeft1_Item","DisplayCategory","Mechanics");
 TweakItem("Base.M151A2BarrierRight1_Item","DisplayCategory","Mechanics");
+end
+
 --78amgeneralM35A2
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2799152995
+if getActivatedMods():contains("78amgeneralM35A2") then
 TweakItem("Base.V100Tire2","DisplayCategory","Mechanics");
 TweakItem("Base.V103Tire2","DisplayCategory","Mechanics");
 TweakItem("Base.V103Axle2","DisplayCategory","Mechanics");
@@ -73,7 +87,11 @@ TweakItem("Base.M35A2Door2","DisplayCategory","Mechanics");
 TweakItem("Base.M35A2WindshieldArmor1_Item","DisplayCategory","Mechanics");
 TweakItem("Base.M35A2DoorArmor1_Item","DisplayCategory","Mechanics");
 TweakItem("Base.M35A2Mudflaps1_Item","DisplayCategory","Mechanics");
+end
+
 --80kz1000
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2818847163
+if getActivatedMods():contains("80kz1000") then
 TweakItem("Base.KZ1Kstorage3","DisplayCategory","Mechanics");
 TweakItem("Base.KZ1Ksidestorage3","DisplayCategory","Mechanics");
 TweakItem("Base.KZ1Kextra3","DisplayCategory","Mechanics");
@@ -87,7 +105,11 @@ TweakItem("Base.KZ1KgasTank","DisplayCategory","Mechanics");
 TweakItem("Base.KZ1Kseat","DisplayCategory","Mechanics");
 TweakItem("Base.KZ1Kwindshield3","DisplayCategory","Mechanics");
 TweakItem("Base.Hat_CHiPsHelmet","DisplayCategory","Cloth");
+end
+
 --83AMGeneralM923
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2811383142
+if getActivatedMods():contains("83amgeneralM923") then
 TweakItem("Base.V100Tire2","DisplayCategory","Mechanics");
 TweakItem("Base.M923Axle2","DisplayCategory","Mechanics");
 TweakItem("Base.M923Trunk2","DisplayCategory","Mechanics");
@@ -113,7 +135,11 @@ TweakItem("Base.M923DoorArmor1_Item","DisplayCategory","Mechanics");
 TweakItem("Base.M923GuntruckArmor1_Item","DisplayCategory","Mechanics");
 TweakItem("Base.M923Mudflaps1_Item","DisplayCategory","Mechanics");
 TweakItem("Base.M923SpareMount1_Item","DisplayCategory","Mechanics");
+end
+
 --84Merc
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2805630347
+if getActivatedMods():contains("84merc") then
 TweakItem("Base.W460NormalTire2","DisplayCategory","Mechanics");
 TweakItem("Base.W460WideTire2","DisplayCategory","Mechanics");
 TweakItem("Base.W460Trunk2","DisplayCategory","Mechanics");
@@ -141,23 +167,43 @@ TweakItem("Base.W460Windshield2","DisplayCategory","Mechanics");
 TweakItem("Base.W460SideWindow2","DisplayCategory","Mechanics");
 TweakItem("Base.W460RearWindshield2","DisplayCategory","Mechanics");
 TweakItem("Base.W460Mudflaps1_Item","DisplayCategory","Mechanics");
+end
+
 --85Merc
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2469388752
+if getActivatedMods():contains("85merc") then
 TweakItem("Base.mercroofrack1","DisplayCategory","Mechanics");
 TweakItem("Base.mercroofrack2","DisplayCategory","Mechanics");
 TweakItem("Base.mercroofrack3","DisplayCategory","Mechanics");
+end
+
 --87Cruiser
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2489148104
+if getActivatedMods():contains("87cruiser") then
 TweakItem("Base.cruiserRoofrack1","DisplayCategory","Mechanics");
 TweakItem("Base.cruiserRoofrack2","DisplayCategory","Mechanics");
 TweakItem("Base.cruiserRoofrack3","DisplayCategory","Mechanics");
+end
+
 --89Defender90
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2443275640
+if getActivatedMods():contains("89def90") then
 TweakItem("Base.def90SpareCompartment1","DisplayCategory","Mechanics");
 TweakItem("Base.def90SpareCompartment2","DisplayCategory","Mechanics");
 TweakItem("Base.def90SpareCompartment3","DisplayCategory","Mechanics");
+end
+
 --89Defender110
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2441990998
+if getActivatedMods():contains("89def110") then
 TweakItem("Base.def110SpareCompartment1","DisplayCategory","Mechanics");
 TweakItem("Base.def110SpareCompartment2","DisplayCategory","Mechanics");
 TweakItem("Base.def110SpareCompartment3","DisplayCategory","Mechanics");
+end
+
 --92AMGeneralM998
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2642541073
+if getActivatedMods():contains("92amgeneralM998") then
 TweakItem("Base.V100Tire2","DisplayCategory","Mechanics");
 TweakItem("Base.V101Tire2","DisplayCategory","Mechanics");
 TweakItem("Base.M998Trunk2","DisplayCategory","Mechanics");
@@ -192,10 +238,18 @@ TweakItem("Base.M101A3TrunkDoorTwo2","DisplayCategory","Mechanics");
 TweakItem("Base.M101A3Cover1_Item","DisplayCategory","Mechanics");
 TweakItem("Base.M101A3Tarp1_Item","DisplayCategory","Mechanics");
 TweakItem("Base.leafSuspension2","DisplayCategory","Mechanics");
+end
+
 --ISOContainers
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2625625421
+if getActivatedMods():contains("isoContainers") then
 TweakItem("Base.IsoContainerTrunkDoor2","DisplayCategory","Mechanics");
 TweakItem("Base.IsoContainerTankerTrunkDoor2","DisplayCategory","Mechanics");
+end
+
 --Oshkosh82M911
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2618213077
+if getActivatedMods():contains("82oshkoshM911") then
 TweakItem("OshkoshShirts.TShirt_OshkoshGray","DisplayCategory","Cloth");
 TweakItem("OshkoshShirts.TShirt_OshkoshBlack","DisplayCategory","Cloth");
 TweakItem("OshkoshShirts.TShirt_bknht","DisplayCategory","Cloth");
@@ -210,8 +264,13 @@ TweakItem("Base.V100AxleSmall2","DisplayCategory","Mechanics");
 TweakItem("Base.M911Trunk2","DisplayCategory","Mechanics");
 TweakItem("Base.M911Toolbox2","DisplayCategory","Mechanics");
 TweakItem("Base.M911SpareTire2","DisplayCategory","Mechanics");
+end
+
 --Oshkosh86P19A
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2566953935
+if getActivatedMods():contains("86oshkoshP19A") then
 TweakItem("Base.V100Tire2","DisplayCategory","Mechanics");
 TweakItem("Base.P19ARoofHatch2","DisplayCategory","Mechanics");
 TweakItem("Base.P19ABigTrunk2","DisplayCategory","Mechanics");
 TweakItem("Base.P19ASmallTrunk2","DisplayCategory","Mechanics");
+end

--- a/media/lua/client/Mod Support/LastCall_Items.lua
+++ b/media/lua/client/Mod Support/LastCall_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --LastCallForAlcohol
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1997978868
+if getActivatedMods():contains("LCFAV2") then
 TweakItem("CCS.MoonshineFull","DisplayCategory","FoodB");
 TweakItem("CCS.MoonshineEmpty","DisplayCategory","Container");
 TweakItem("CCS.MoonshineBottleWater","DisplayCategory","FoodB");
@@ -52,3 +54,4 @@ TweakItem("CCS.DarkBeerCanSixPack","DisplayCategory","FoodB");
 TweakItem("CCS.TripleSecFull","DisplayCategory","FoodB");
 TweakItem("CCS.TripleSecEmpty","DisplayCategory","Container");
 TweakItem("CCS.TripleSecBottleWater","DisplayCategory","FoodB");
+end

--- a/media/lua/client/Mod Support/LiteratureandMagazines_Items.lua
+++ b/media/lua/client/Mod Support/LiteratureandMagazines_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --LITERATUREANDMAGAZINES
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2440051148
+if getActivatedMods():contains("Literature&Magazines") then
 --Literature
 TweakItem("Literature.BookTheHobbitorThereandBackAgain","DisplayCategory","LitE");
 TweakItem("Literature.BookTheFellowshipoftheRing","DisplayCategory","LitE");
@@ -1184,3 +1186,4 @@ TweakItem("Literature.ComicBookTales","DisplayCategory","LitE");
 TweakItem("Literature.ComicBookTales2","DisplayCategory","LitE");
 TweakItem("Literature.ComicBookDareDevil","DisplayCategory","LitE");
 TweakItem("Literature.ComicBookDareDevil2","DisplayCategory","LitE");
+end

--- a/media/lua/client/Mod Support/LittleYoschisSkillbooks_Items.lua
+++ b/media/lua/client/Mod Support/LittleYoschisSkillbooks_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --LittleYochisSkillbooks
+--???
+--if getActivatedMods():contains("???") then
 TweakItem("LY_Skillbooks.BookSprinting1","DisplayCategory","LitS");
 TweakItem("LY_Skillbooks.BookSprinting2","DisplayCategory","LitS");
 TweakItem("LY_Skillbooks.BookSprinting3","DisplayCategory","LitS");
@@ -81,3 +83,4 @@ TweakItem("LY_Skillbooks.BookStrength2","DisplayCategory","LitS");
 TweakItem("LY_Skillbooks.BookStrength3","DisplayCategory","LitS");
 TweakItem("LY_Skillbooks.BookStrength4","DisplayCategory","LitS");
 TweakItem("LY_Skillbooks.BookStrength5","DisplayCategory","LitS");
+--end

--- a/media/lua/client/Mod Support/MRE_XIII_Items.lua
+++ b/media/lua/client/Mod Support/MRE_XIII_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --MRE XIII
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1521582441
+if getActivatedMods():contains("1521582441") then
 --Food
 TweakItem("USMRE.MREbox","DisplayCategory","FoodN");
 TweakItem("USMRE.MREmenu01","DisplayCategory","FoodN");
@@ -109,3 +111,4 @@ TweakItem("USMRE.MREboxPallet09","DisplayCategory","FoodN");
 TweakItem("USMRE.MREboxPallet10","DisplayCategory","FoodN");
 TweakItem("USMRE.MREboxPallet11","DisplayCategory","FoodN");
 TweakItem("USMRE.MREboxPallet12","DisplayCategory","FoodN");
+end

--- a/media/lua/client/Mod Support/Madax_Items.lua
+++ b/media/lua/client/Mod Support/Madax_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --Melee Weapons Pack
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2492565135
+if getActivatedMods():contains("Max") then
 TweakItem("MWPWeapons.fiskarcurvedmachete","DisplayCategory","WepMelee");
 TweakItem("MWPWeapons.aluminiumbaseballbat","DisplayCategory","WepMelee");
 TweakItem("MWPWeapons.muelahuntingknife","DisplayCategory","WepMelee");
@@ -51,7 +53,11 @@ TweakItem("MWPWeapons.reavercleaver","DisplayCategory","WepMelee");
 TweakItem("MWPWeapons.coldsteelspear","DisplayCategory","WepMelee");
 TweakItem("MWPWeapons.taigamachete","DisplayCategory","WepMelee");
 TweakItem("MWPWeapons.dmmiceaxe","DisplayCategory","WepMelee");
+end
+
 --Akier Machete
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2798493195
+if getActivatedMods():contains("MDXakiermachete") then
 TweakItem("Base.akiermachete","DisplayCategory","WepMelee");
 TweakItem("Base.akiermacheteshortmod","DisplayCategory","WepMelee");
 TweakItem("Base.akiermacheteergonomicmod","DisplayCategory","WepMelee");
@@ -59,13 +65,22 @@ TweakItem("Base.akiermacheteergonomic&shortmod","DisplayCategory","WepMelee");
 TweakItem("Base.akiermachetebarbedmod","DisplayCategory","WepMelee");
 TweakItem("Base.akiermachetebleedmod","DisplayCategory","WepMelee");
 TweakItem("Base.akiermacheteergonomic&bleedmod","DisplayCategory","WepMelee");
+end
+
 --Elgor Camp Axe
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2748133073
+if getActivatedMods():contains("MDXelgorcampaxe") then
 TweakItem("Base.elgorcampaxe","DisplayCategory","WepMelee");
 TweakItem("Base.elgorcampaxehammermod","DisplayCategory","WepMelee");
 TweakItem("Base.elgorcampaxepiercemod","DisplayCategory","WepMelee");
+end
+
 --Rager Baseball Bat
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2693183552
+if getActivatedMods():contains("MDXragerbaseballbat") then
 TweakItem("Base.ragerbaseballbat","DisplayCategory","WepMelee");
 TweakItem("Base.ragerbaseballbatnailmod","DisplayCategory","WepMelee");
 TweakItem("Base.ragerbaseballbatbarbedmod","DisplayCategory","WepMelee");
 TweakItem("Base.ragerbaseballbatheavymod","DisplayCategory","WepMelee");
 TweakItem("Base.ragerbaseballbataxemod","DisplayCategory","WepMelee");
+end

--- a/media/lua/client/Mod Support/MoreBooks_Items.lua
+++ b/media/lua/client/Mod Support/MoreBooks_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --More Books!
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2815857931
+if getActivatedMods():contains("MoreBooks") then
 --Literature Entertainment
 TweakItem("Books.Book","DisplayCategory","LitE");
 TweakItem("Books.Nineteen_Eighty-Four","DisplayCategory","LitE");
@@ -103,3 +105,4 @@ TweakItem("Books.Romeo_and_Juliet","DisplayCategory","LitE");
 TweakItem("Books.The_Diary_of_a_Young_Girl","DisplayCategory","LitE");
 TweakItem("Books.Factotum","DisplayCategory","LitE");
 TweakItem("Books.The_Art_of_War","DisplayCategory","LitE");
+end

--- a/media/lua/client/Mod Support/MoreCigsMod_Items.lua
+++ b/media/lua/client/Mod Support/MoreCigsMod_Items.lua
@@ -1,6 +1,10 @@
 require("ItemTweaker_Copy_CC");
 
 --MORECIGSMOD
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2396329386
+if getActivatedMods():contains("MoreCigsMod") 
+or getActivatedMods():contains("MCMGreenfire") 
+or getActivatedMods():contains("MCMLitter") then
 --Drugs
 TweakItem("Cigs.CigsCigaretteReg","DisplayCategory","Drugs");
 TweakItem("Cigs.CigsButtReg","DisplayCategory","Drugs");
@@ -84,3 +88,4 @@ TweakItem("Greenfire.TobaccoPipe","DisplayCategory","Drugs");
 TweakItem("Greenfire.TobaccoSeed","DisplayCategory","SurFarm");
 TweakItem("Greenfire.TobaccoBagSeed","DisplayCategory","SurFarm");
 TweakItem("Greenfire.PipeTobaccoBag","DisplayCategory","Drugs");
+end

--- a/media/lua/client/Mod Support/MoreMaps_Items.lua
+++ b/media/lua/client/Mod Support/MoreMaps_Items.lua
@@ -2,6 +2,8 @@ require("ItemTweaker_Copy_CC");
 --Courtesy of inhuman
 
 --MoreMaps
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2729427093
+if getActivatedMods():contains("MoreMaps") then
 --MAPS
 TweakItem("Base.KentuckyMap","DisplayCategory","Map");
 TweakItem("Base.EkronMap","DisplayCategory","Map");
@@ -100,3 +102,4 @@ TweakItem("Base.CoryerdonMap","DisplayCategory","Map");
 TweakItem("Base.EastCoryerdonMap","DisplayCategory","Map");
 TweakItem("Base.SouthCoryerdonMap","DisplayCategory","Map");
 TweakItem("Base.CenterCoryerdonMap","DisplayCategory","Map");
+end

--- a/media/lua/client/Mod Support/MoreSkillBooks_Items.lua
+++ b/media/lua/client/Mod Support/MoreSkillBooks_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --MoreSkillBooks
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2462898835
+if getActivatedMods():contains("MoreSkillBooks") then
 TweakItem("MoreSkillBooks.BookFitness1","DisplayCategory","LitS");
 TweakItem("MoreSkillBooks.BookFitness2","DisplayCategory","LitS");
 TweakItem("MoreSkillBooks.BookFitness3","DisplayCategory","LitS");
@@ -76,3 +78,4 @@ TweakItem("MoreSkillBooks.BookReloading2","DisplayCategory","LitS");
 TweakItem("MoreSkillBooks.BookReloading3","DisplayCategory","LitS");
 TweakItem("MoreSkillBooks.BookReloading4","DisplayCategory","LitS");
 TweakItem("MoreSkillBooks.BookReloading5","DisplayCategory","LitS");
+end

--- a/media/lua/client/Mod Support/NukaColaCollection_Items.lua
+++ b/media/lua/client/Mod Support/NukaColaCollection_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --NukaColaCollection
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2613274731
+if getActivatedMods():contains("NukaColaCollection") then
 TweakItem("nuka.NukaCherry","DisplayCategory","FoodB");
 TweakItem("nuka.NukaCherryOpen","DisplayCategory","FoodB");
 TweakItem("nuka.EmptyNukaCherry","DisplayCategory","Container");
@@ -55,3 +57,4 @@ TweakItem("nuka.NukaWildOpen","DisplayCategory","FoodB");
 TweakItem("nuka.EmptyNukaWild","DisplayCategory","Container");
 TweakItem("nuka.NukaWildWater","DisplayCategory","FoodB");
 TweakItem("nuka.NukaWildCap","DisplayCategory","Junk");
+end

--- a/media/lua/client/Mod Support/OGSN_Items.lua
+++ b/media/lua/client/Mod Support/OGSN_Items.lua
@@ -1,12 +1,19 @@
 require("ItemTweaker_Copy_CC");
 
 --LockpickingOnly
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2056238799
+if getActivatedMods():contains("LockpickingOnly") then
 TweakItem("FMJ.LockPickingMag","DisplayCategory","LitR");
 TweakItem("FMJ.LockPickingMag2","DisplayCategory","LitR");
 TweakItem("FMJ.BobbyPin","DisplayCategory","Tool");
 TweakItem("FMJ.BobbyPinRaw","DisplayCategory","Tool");
+end
+
 --OGSN ORPHANAGE
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2079001985
+
 --ForkMJdairy
+if getActivatedMods():contains("ForkMJdairy") then
 TweakItem("Base.DairyCookingMag","DisplayCategory","LitR");
 TweakItem("Base.Strainer","DisplayCategory","Cooking");
 TweakItem("Base.PowderedMilk","DisplayCategory","FoodN");
@@ -19,7 +26,10 @@ TweakItem("Base.YogurtPrep","DisplayCategory","FoodP");
 TweakItem("Base.YogurtJar","DisplayCategory","FoodP");
 TweakItem("Base.Butter","DisplayCategory","FoodN");
 TweakItem("Base.Yoghurt","DisplayCategory","FoodP");
+end
+
 --ForkMJfoodWild
+if getActivatedMods():contains("ForkMJfoodWild") then
 TweakItem("FMJ.BirchBark","DisplayCategory","SurCamp");
 TweakItem("FMJ.Dandelions","DisplayCategory","FoodP");
 TweakItem("FMJ.Herbs","DisplayCategory","FoodN");
@@ -43,7 +53,10 @@ TweakItem("FMJ.Omelettes","DisplayCategory","FoodP");
 TweakItem("FMJ.PotatoPancakes","DisplayCategory","FoodP");
 TweakItem("FMJ.RollUps","DisplayCategory","Misc");
 TweakItem("FMJ.QRollUps","DisplayCategory","Misc");
+end
+
 --ForkMJjarMeat
+if getActivatedMods():contains("ForkMJjarMeat") then
 TweakItem("FMJ.JarLizard","DisplayCategory","FoodP");
 TweakItem("FMJ.JarPheasant","DisplayCategory","FoodP");
 TweakItem("FMJ.JarSnake","DisplayCategory","FoodP");
@@ -57,7 +70,10 @@ TweakItem("FMJ.JarRabbitmeat","DisplayCategory","FoodP");
 TweakItem("FMJ.JarSmallanimalmeat","DisplayCategory","FoodP");
 TweakItem("FMJ.JarSmallbirdmeat","DisplayCategory","FoodP");
 TweakItem("FMJ.JarSalmon","DisplayCategory","FoodP");
+end
+
 --OGSN_Orphan_OrganizedStorage
+if getActivatedMods():contains("OGSN_Orphan_OrganizedStorage") then
 TweakItem("GidOrganized.OS30pkAntibiotics","DisplayCategory","Medical");
 TweakItem("GidOrganized.OS12pkAdhesiveBandages","DisplayCategory","Medical");
 TweakItem("GidOrganized.OS9pkBandages","DisplayCategory","Medical");
@@ -94,8 +110,10 @@ TweakItem("GidOrganizedFood.OS8pkWhiskeyEmpty","DisplayCategory","Container");
 TweakItem("GidOrganizedFood.OS24pkWaterBottleEmpty","DisplayCategory","Container");
 TweakItem("GidOrganizedFood.OS24pkWaterBottleFull","DisplayCategory","FoodB");
 TweakItem("GidOrganizedFood.OS4pkDuctTape","DisplayCategory","Craft");
-if getActivatedMods():contains("OGSN_Orphan_RodsStore") then
+end
+
 --OGSN_Orphan_RodsStore
+if getActivatedMods():contains("OGSN_Orphan_RodsStore") then
 TweakItem("RS.KnuckleKnife","DisplayCategory","WepMelee");
 TweakItem("RS.PoliceKnife","DisplayCategory","WepMelee");
 TweakItem("RS.CombatKnife","DisplayCategory","WepMelee");
@@ -216,9 +234,18 @@ TweakItem("RS.Cream","DisplayCategory","FoodP");
 TweakItem("RS.CherriesJar","DisplayCategory","FoodN");
 TweakItem("RS.Pepperoni","DisplayCategory","FoodN");
 end
+
 --OSGNTieOnSpearHead
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2036922754
+if getActivatedMods():contains("TieOnSpearheads") 
+or getActivatedMods():contains("TieOnSpearheads_MP") 
+or getActivatedMods():contains("TieOnSpearheads_Crafting") then
 TweakItem("Base.SpearChippedStone","DisplayCategory","WepMelee");
+end
+
 --VanillaFoodFixes
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2072147750
+if getActivatedMods():contains("VFFogsn") or getActivatedMods():contains("VFFogsn_herbsNoRot") then
 TweakItem("Base.StirFryBowl","DisplayCategory","FoodP");
 TweakItem("Base.RoastedVegetablesBowl","DisplayCategory","FoodP");
 TweakItem("Base.RosehipsDried","DisplayCategory","FoodN");
@@ -240,3 +267,4 @@ TweakItem("Base.BlackSageDried","DisplayCategory","Medical");
 TweakItem("Base.GinsengDried","DisplayCategory","Medical");
 TweakItem("Base.PlantainDried","DisplayCategory","Medical");
 TweakItem("Base.WildGarlicDried","DisplayCategory","Medical");
+end

--- a/media/lua/client/Mod Support/OccupationsExpertises_Items.lua
+++ b/media/lua/client/Mod Support/OccupationsExpertises_Items.lua
@@ -1,7 +1,9 @@
 require "ItemTweaker_Copy_CC"
 --Courtesy of Elzetia
 
--- Book Occupations Expertises
+--Book Occupations Expertises
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2729436580
+if getActivatedMods():contains("OccupationsExpertises") then
 TweakItem("OccupationsExpertises.BookFitness1","DisplayCategory","LitS");
 TweakItem("OccupationsExpertises.BookFitness2","DisplayCategory","LitS");
 TweakItem("OccupationsExpertises.BookFitness3","DisplayCategory","LitS");
@@ -76,3 +78,4 @@ TweakItem("OccupationsExpertises.BookReloading2","DisplayCategory","LitS");
 TweakItem("OccupationsExpertises.BookReloading3","DisplayCategory","LitS");
 TweakItem("OccupationsExpertises.BookReloading4","DisplayCategory","LitS");
 TweakItem("OccupationsExpertises.BookReloading5","DisplayCategory","LitS");
+end

--- a/media/lua/client/Mod Support/Orcs_Items.lua
+++ b/media/lua/client/Mod Support/Orcs_Items.lua
@@ -1,27 +1,39 @@
 require("ItemTweaker_Copy_CC");
 
 --Improvised Paint
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2789503316
+if getActivatedMods():contains("ImprovisedPaint") then
 TweakItem("ImprovisedPaint.ColorYourWorldMagazine","DisplayCategory","LitR");
 TweakItem("ImprovisedPaint.DIYCraftsMagazine","DisplayCategory","LitR");
 TweakItem("ImprovisedPaint.DIYCraftsMagazine2","DisplayCategory","LitR");
+end
 
 --Improvised Flooring
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2790428261
+if getActivatedMods():contains("ImprovisedFlooring") or getActivatedMods():contains("ImprovisedFlooringPlus") then
 TweakItem("ImprovisedFlooring.IFMagazineEasterEgg","DisplayCategory","LitR");
 TweakItem("ImprovisedFlooring.IFMagazineFranchise","DisplayCategory","LitR");
 TweakItem("ImprovisedFlooring.IFMagazineGarden","DisplayCategory","LitR");
 TweakItem("ImprovisedFlooring.IFMagazineIndustrial","DisplayCategory","LitR");
 TweakItem("ImprovisedFlooring.IFMagazineTiles","DisplayCategory","LitR");
 TweakItem("ImprovisedFlooring.IFMagazineUrban","DisplayCategory","LitR");
+end
 
 --Improvised Glass
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2800412098
+if getActivatedMods():contains("ImprovisedGlass") then
 TweakItem("ImprovisedGlass.PanWithGlassShards","DisplayCategory","Craft");
 TweakItem("ImprovisedGlass.PanWithGlassPane","DisplayCategory","Craft");
 TweakItem("ImprovisedGlass.GlassPane","DisplayCategory","Craft");
 TweakItem("ImprovisedGlass.IGMagazineGlass","DisplayCategory","LitR");
 TweakItem("ImprovisedGlass.IGMagazineWindow","DisplayCategory","LitR");
 TweakItem("ImprovisedGlass.IGMagazineCars","DisplayCategory","LitR");
+end
 
 --Improvised Cabinetry
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2810378872
+if getActivatedMods():contains("ImprovisedCabinetry") then
 TweakItem("ImprovisedCabinetry.ICMagazine1","DisplayCategory","LitR");
 TweakItem("ImprovisedCabinetry.WoodPanel","DisplayCategory","CraftCarp");
 TweakItem("ImprovisedCabinetry.SmallHinge","DisplayCategory","CraftCarp");
+end

--- a/media/lua/client/Mod Support/PLLoot_Items.lua
+++ b/media/lua/client/Mod Support/PLLoot_Items.lua
@@ -1,6 +1,10 @@
 require("ItemTweaker_Copy_CC");
 
 --PLLOOT
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2279084780
+if getActivatedMods():contains("PLLoot") 
+or getActivatedMods():contains("PLLootF") 
+or getActivatedMods():contains("PLLootG") then
 TweakItem("Base.Animask1","DisplayCategory","ClothA");
 TweakItem("Base.Animask12","DisplayCategory","ClothA");
 TweakItem("Base.Animask13","DisplayCategory","ClothA");
@@ -125,4 +129,4 @@ TweakItem("Base.MP5GL2","DisplayCategory","WepFire");
 TweakItem("Base.Vulcan","DisplayCategory","WepFire");
 TweakItem("Base.Tanto","DisplayCategory","WepMelee");
 TweakItem("Base.WitchyStaff","DisplayCategory","WepMelee");
-
+end

--- a/media/lua/client/Mod Support/PaintYourRide_Items.lua
+++ b/media/lua/client/Mod Support/PaintYourRide_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --PaintYourRide
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2281256511
+if getActivatedMods():contains("PaintYourRide") then
 TweakItem("PaintYourRide.VehiclePaintingMag1","DisplayCategory","LitR");
 TweakItem("PaintYourRide.VehiclePaintingMag2","DisplayCategory","LitR");
 TweakItem("PaintYourRide.SprayGun","DisplayCategory","Paint");
@@ -49,3 +51,4 @@ TweakItem("PaintYourRide.AutomotiveSprayPaintWhite","DisplayCategory","Paint");
 TweakItem("PaintYourRide.AutomotiveSprayPaintYellow","DisplayCategory","Paint");
 TweakItem("PaintYourRide.AutomotiveSprayPaintYellowNeon","DisplayCategory","Paint");
 TweakItem("PaintYourRide.AutomotiveSprayPaintYellowTuscany","DisplayCategory","Paint");
+end

--- a/media/lua/client/Mod Support/PantryPacking_Items.lua
+++ b/media/lua/client/Mod Support/PantryPacking_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC")
 
 --PantryPacking
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2637692469
+if getActivatedMods():contains("PantryPacking") then
 TweakItem("Base.BookBox","DisplayCategory","LitS");
 TweakItem("Base.BookBoxCarpentry","DisplayCategory","LitS");
 TweakItem("Base.BookBoxTrapping","DisplayCategory","LitS");
@@ -57,3 +59,4 @@ TweakItem("Base.BoxOfCanCocktail","DisplayCategory","FoodN");
 TweakItem("Base.BoxOfCanPineapple","DisplayCategory","FoodN");
 TweakItem("Base.BoxOfJamFruit","DisplayCategory","FoodN");
 TweakItem("Base.BoxOfJamMarmalade","DisplayCategory","FoodN");
+end

--- a/media/lua/client/Mod Support/Planetalgol_Items.lua
+++ b/media/lua/client/Mod Support/Planetalgol_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --AdvancedGEAR
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2050264961
+if getActivatedMods():contains("ADVANCEDGEAR") then
 TweakItem("Base.AssaultBoots","DisplayCategory","Cloth");
 TweakItem("Base.AssaultBootsDesert","DisplayCategory","Cloth");
 TweakItem("Base.CalfSheath","DisplayCategory","ClothA");
@@ -296,9 +298,18 @@ TweakItem("Base.MRE_FlamelessRationHeater_Trash","DisplayCategory","Junk");
 --GEAR
 TweakItem("Base.MakeUp_GreenCamo","DisplayCategory","ClothM");
 TweakItem("Base.MakeUp_GreenCamo2","DisplayCategory","ClothM");
+end
+
 --KeyTool
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2266521599
+if getActivatedMods():contains("Keytool") then
 TweakItem("Keytool.KeyRing","DisplayCategory","ClothA");
+end
+
 --Slim Jim
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2793314838
+if getActivatedMods():contains("SlimJimLockoutTool") then
 TweakItem("Base.PA_SlimJim","DisplayCategory","Tool");
 TweakItem("Base.PA_TrueCrimeMag2","DisplayCategory","LitR");
 TweakItem("Base.PA_TrueCrimeMag2_b","DisplayCategory","LitR");
+end

--- a/media/lua/client/Mod Support/Ramen_Items.lua
+++ b/media/lua/client/Mod Support/Ramen_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --RAMEN
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2382777667
+if getActivatedMods():contains("Ramen") then
 --Food
 TweakItem("Ramen.RamenChickenFlat","DisplayCategory","FoodN");
 TweakItem("Ramen.RamenChickenPack","DisplayCategory","FoodN");
@@ -46,4 +48,4 @@ TweakItem("Ramen.RamenShrimpPackEmpty","DisplayCategory","Junk");
 TweakItem("Ramen.RamenShrimpFlavEmpty","DisplayCategory","Junk");
 TweakItem("Ramen.RamenCheesePackEmpty","DisplayCategory","Junk");
 TweakItem("Ramen.RamenCheeseFlavEmpty","DisplayCategory","Junk");
-
+end

--- a/media/lua/client/Mod Support/RuggedRecipes_Items.lua
+++ b/media/lua/client/Mod Support/RuggedRecipes_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
---PowderedMilkPouch
+--RuggedRecipes
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2715579154
+if getActivatedMods():contains("RuggedRecipes") then
 --FARMING
 TweakItem("RuggedRecipes.Cucumber","DisplayCategory","FoodP");
 --ALCOHOL
@@ -71,3 +73,4 @@ TweakItem("RuggedRecipes.RuggedRecipesMagazine4","DisplayCategory","LitR");
 --SEED
 TweakItem("RuggedRecipes.RuggedRecipesMagazine4","CucumberSeed","SurFarm");
 TweakItem("RuggedRecipes.RuggedRecipesMagazine4","CucumberBagSeed","SurFarm");
+end

--- a/media/lua/client/Mod Support/Shark-cyts_Items.lua
+++ b/media/lua/client/Mod Support/Shark-cyts_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --BRDM-2
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2782916681
+if getActivatedMods():contains("BRDM2") then
 TweakItem("Base.BRDM2VehicleInterior","DisplayCategory","Mechanics");
 TweakItem("Base.BRDM2Tire","DisplayCategory","Mechanics");
 TweakItem("Base.ModernBrake8","DisplayCategory","Mechanics");
@@ -15,8 +17,12 @@ TweakItem("Base.EngineDoor8","DisplayCategory","Mechanics");
 TweakItem("Base.TrunkDoor8","DisplayCategory","Mechanics");
 TweakItem("Base.XM93Seat","DisplayCategory","Mechanics");
 TweakItem("Base.ModernCarMuffler8","DisplayCategory","Mechanics");
+end
+
 --Courtesy of Athigo 
 --Expanded Helicopter Event
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2458631365
+if getActivatedMods():contains("ExpandedHelicopterEvents") then
 TweakItem("EHE.Hat_SPHPolice","DisplayCategory","Cloth");
 TweakItem("EHE.Hat_SPHPoliceVISORUP","DisplayCategory","Cloth");
 TweakItem("EHE.Hat_SPHMilitary","DisplayCategory","Cloth");
@@ -58,7 +64,11 @@ TweakItem("EHE.SurvivorFishingSupplyBox","DisplayCategory","Container");
 TweakItem("EHE.SurvivorSeedSupplyBox","DisplayCategory","Container");
 TweakItem("EHE.SurvivorCanningSupplyBox","DisplayCategory","Container");
 TweakItem("EHE.SurvivorToiletSupplyBox","DisplayCategory","Container");
+end
+
 --Fighter Pilot
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2756035778
+if getActivatedMods():contains("CSPT") then
 TweakItem("HouseMODS.CSU_13","DisplayCategory","Cloth");
 TweakItem("HouseMODS.HGU55","DisplayCategory","Cloth");
 TweakItem("HouseMODS.HGU55_blue","DisplayCategory","Cloth");
@@ -82,7 +92,11 @@ TweakItem("HouseMODS.NOMEX","DisplayCategory","Cloth");
 TweakItem("HouseMODS.Harness","DisplayCategory","Cloth");
 TweakItem("HouseMODS.SurvivalV","DisplayCategory","Cloth");
 TweakItem("HouseMODS.LPU","DisplayCategory","Cloth");
+end
+
 --Interim Fast Attack Vehicle (IFAV)
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2797176641
+if getActivatedMods():contains("IFAV") then
 TweakItem("Base.IFAVDoor2","DisplayCategory","Mechanics");
 TweakItem("Base.IFAVWindshield2","DisplayCategory","Mechanics");
 TweakItem("Base.IFAVWindshieldFrame2","DisplayCategory","Mechanics");
@@ -90,7 +104,11 @@ TweakItem("Base.IFAVFrontBumper2","DisplayCategory","Mechanics");
 TweakItem("Base.IFAVFrontTop2","DisplayCategory","Mechanics");
 TweakItem("Base.IFAVRearTop2","DisplayCategory","Mechanics");
 TweakItem("Base.IFAVSideCovers2","DisplayCategory","Mechanics");
+end
+
 --Shark and Cytt's Kentucky Car Overhaul
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2807356025
+if getActivatedMods():contains("SCKCO") then
 TweakItem("Base.K5Bullbar2","DisplayCategory","Mechanics");
 TweakItem("Base.K5Chevy2","DisplayCategory","Mechanics");
 TweakItem("Base.K5DoorSC2","DisplayCategory","Mechanics");
@@ -133,7 +151,11 @@ TweakItem("Base.CapriceFrontSeatSC2","DisplayCategory","Mechanics");
 TweakItem("Base.CapriceRearSeatSC2","DisplayCategory","Mechanics");
 TweakItem("Base.CapriceWheelSC2","DisplayCategory","Mechanics");
 TweakItem("Base.SCInteriorArmory","DisplayCategory","Mechanics");
+end
+
 --Shark&Peach Military Uniform
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2530389024
+if getActivatedMods():contains("SMUI") then
 TweakItem("SMUIClothing.NightVisionGoggles","DisplayCategory","ClothA");
 TweakItem("SMUIClothing.NightVisionMount","DisplayCategory","ClothA");
 TweakItem("SMUIClothing.MilitaryWebbingSuspenders","DisplayCategory","ClothA");
@@ -258,7 +280,11 @@ TweakItem("SMUIClothing.MilitaryWebbingBag","DisplayCategory","Container");
 TweakItem("SMUIClothing.MilitaryWebbingBagTightened","DisplayCategory","Container");
 TweakItem("SMUIClothing.PistolBeltPouches","DisplayCategory","Container");
 TweakItem("SMUIClothing.PistolBeltBag","DisplayCategory","Container");
+end
+
 --Shark's Law Enforcement Overhaul
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2616752828
+if getActivatedMods():contains("SLEO") then
 TweakItem("SLEOClothing.Bag_DuffelPolice","DisplayCategory","Container");
 TweakItem("SLEOClothing.Bag_DuffelSheriff","DisplayCategory","Container");
 TweakItem("SLEOClothing.Bag_PoliceUtilityBag","DisplayCategory","Container");
@@ -306,10 +332,19 @@ TweakItem("SLEOClothing.Trousers_PoliceTacticalBlack","DisplayCategory","Cloth")
 TweakItem("SLEOClothing.Trousers_PoliceTacticalBlackTucked","DisplayCategory","Cloth");
 TweakItem("SLEOClothing.Trousers_SheriffTactical","DisplayCategory","Cloth");
 TweakItem("SLEOClothing.Trousers_SheriffTacticalTucked","DisplayCategory","Cloth");
+end
+
 --XM93_CBRN
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2782916396
+if getActivatedMods():contains("XM93") then
 TweakItem("Base.XM93LabContainer","DisplayCategory","Mechanics");
 TweakItem("Base.XM93VehicleInterior","DisplayCategory","Mechanics");
+end
+
 --'93 FJ75 Land Cruiser Pickup
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2812534580&searchtext=
+if getActivatedMods():contains("FJ75C") then
 TweakItem("Base.FJ75DoorArmor2","DisplayCategory","Mechanics");
 TweakItem("Base.FJ75WindshieldArmor2","DisplayCategory","Mechanics");
 TweakItem("Base.FJ75Bullbar2","DisplayCategory","Mechanics");
+end

--- a/media/lua/client/Mod Support/SmallMod_Items.lua
+++ b/media/lua/client/Mod Support/SmallMod_Items.lua
@@ -2,6 +2,8 @@ require("ItemTweaker_Copy_CC");
 --Mods with 30 or fewer added new items--
 
 --AlecMods
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1537876121
+if getActivatedMods():contains("1537876121") then
 TweakItem("BottlingFish.BottlingFishFillet","DisplayCategory","FoodP");
 TweakItem("BottlingFish.BottlingSalmon","DisplayCategory","FoodP");
 TweakItem("Bottling.BottlingChicken","DisplayCategory","FoodP");
@@ -18,7 +20,11 @@ TweakItem("Bottling.BottlingBaconBits","DisplayCategory","FoodP");
 TweakItem("Bottling.BottlingBaconRashers","DisplayCategory","FoodP");
 TweakItem("Bottling.BottlingHam","DisplayCategory","FoodP");
 TweakItem("Base.JarLidBoxs","DisplayCategory","Misc");
+end
+
 --AlfretysAdditionalSodas
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2427699853
+if getActivatedMods():contains("AAS") then
 TweakItem("AAS.MountainDew","DisplayCategory","FoodB");
 TweakItem("AAS.Pepsi","DisplayCategory","FoodB");
 TweakItem("AAS.RCCola","DisplayCategory","FoodB");
@@ -47,7 +53,11 @@ TweakItem("AAS.DrPepperEmpty","DisplayCategory","Junk");
 TweakItem("AAS.FantaGrapeEmpty","DisplayCategory","Junk");
 TweakItem("AAS.RCColaEmpty","DisplayCategory","Junk");
 TweakItem("AAS.CrushedCan","DisplayCategory","Junk");
+end
+
 --AnalginsRenewableResources
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2688622178
+if getActivatedMods():contains("AnaLGiNs_RenewableFoodResources") then
 TweakItem("ANL.SmallSaltRock","DisplayCategory","Craft");
 TweakItem("ANL.WildYeastBase","DisplayCategory","Cooking");
 TweakItem("ANL.JarOfYeast","DisplayCategory","Cooking");
@@ -63,7 +73,14 @@ TweakItem("ANL.GratedBerries","DisplayCategory","FoodP");
 TweakItem("ANL.JarOfCrushedBerries","DisplayCategory","Cooking");
 TweakItem("ANL.WildBerryWine","DisplayCategory","FoodB");
 TweakItem("ANL.JarOfVinegarBase","DisplayCategory","Cooking");
+end
+
 --Anitserum
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2127326898
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2685311348
+if getActivatedMods():contains("antiserum") 
+or getActivatedMods():contains("antiserum_beta") 
+or getActivatedMods():contains("AntiserumHC") then
 TweakItem("Antiserum.AntiserumChemicals","DisplayCategory","Medical");
 TweakItem("Antiserum.AntiserumChemicalWorkstation","DisplayCategory","Medical");
 TweakItem("Antiserum.AntiserumSample","DisplayCategory","Medical");
@@ -76,9 +93,17 @@ TweakItem("Antiserum.AntiserumCure","DisplayCategory","Medical");
 TweakItem("Antiserum.AntiserumUsedInjector","DisplayCategory","Medical");
 TweakItem("Antiserum.AntiserumEmptyInjector","DisplayCategory","Medical");
 TweakItem("Antiserum.AntiserumEmptyInjectorPack","DisplayCategory","Medical");
+end
+
 --AntiserumSelfTestKit
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2727546169
+if getActivatedMods():contains("AntiserumHCSelfTestKit") then
 TweakItem("AntiserumTestKit.AntiserumTestKit","DisplayCategory","Medical");
+end
+
 --ArmoredVests
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1962761540
+if getActivatedMods():contains("ArmoredVests") then
 TweakItem("Armor.Vest_BulletArmy","DisplayCategory","Cloth");
 TweakItem("Armor.Vest_BulletPolice","DisplayCategory","Cloth");
 TweakItem("Armor.Vest_BulletCivilian","DisplayCategory","Cloth");
@@ -89,20 +114,36 @@ TweakItem("Armor.Hat_SPHhelmet","DisplayCategory","Cloth");
 TweakItem("Armor.Hat_GasMask","DisplayCategory","Cloth");
 TweakItem("Armor.Hat_BalaclavaFace","DisplayCategory","Cloth");
 TweakItem("Armor.Hat_BalaclavaFull","DisplayCategory","Cloth");
+end
+
 --AutoGate
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2735447453
+if getActivatedMods():contains("AutoGate") then
 TweakItem("AutoGate.AutoGateMag","DisplayCategory","LitR");
 TweakItem("AutoGate.GateController","DisplayCategory","Electronics");
 TweakItem("AutoGate.GateComponents","DisplayCategory","CraftElec");
+end
+
 --AxesRecrafting
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2211423190
+if getActivatedMods():contains("2211423190") then
 TweakItem("AxeRecrafting.AxeHandle","DisplayCategory","Craft");
 TweakItem("AxeRecrafting.FireAxeHead","DisplayCategory","Craft");
 TweakItem("AxeRecrafting.WoodAxeHead","DisplayCategory","Craft");
 TweakItem("AxeRecrafting.HandAxeHead","DisplayCategory","Craft");
 TweakItem("AxeRecrafting.MetalAxeHandle","DisplayCategory","Craft");
+end
+
 --BCGRareWeapons
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2432621382
+if getActivatedMods():contains("BCGRareWeapons") then
 TweakItem("BCGRareWeapons.ReinforcedBaseballBat","DisplayCategory","WepMelee");
 TweakItem("BCGRareWeapons.VikingAxe","DisplayCategory","WepMelee");
+end
+
 --BCGTools
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2423906082
+if getActivatedMods():contains("BCGTools") then
 TweakItem("BCGTools.HandHatchet","DisplayCategory","WepMelee");
 TweakItem("BCGTools.CheapSurvivalKnife","DisplayCategory","WepMelee");
 TweakItem("BCGTools.SurvivalKnife","DisplayCategory","WepMelee");
@@ -111,9 +152,17 @@ TweakItem("BCGTools.KukriMachete","DisplayCategory","WepMelee");
 TweakItem("BCGTools.SplittingAxe","DisplayCategory","WepMelee");
 TweakItem("BCGTools.SpearSurvivalKnife","DisplayCategory","WepMelee");
 TweakItem("BCGTools.SpearCheapSurvivalKnife","DisplayCategory","WepMelee");
+end
+
 --Bedford Falls
+--https://steamcommunity.com/sharedfiles/filedetails/?id=522891356
+if getActivatedMods():contains("BedfordFalls") then
 TweakItem("Base.BedfordMap","DisplayCategory","Map");
+end
+
 --Better Flashlights
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2766033079
+if getActivatedMods():contains("BetterFlashlights") then
 TweakItem("Base.BF_HeadLight","DisplayCategory","Tool");
 TweakItem("Base.Hat_HardHat_Miner_With_Light","DisplayCategory","Cloth");
 TweakItem("Base.HandTorch_CK_LED","DisplayCategory","Tool");
@@ -132,18 +181,38 @@ TweakItem("Base.TorchArmy2","DisplayCategory","Tool");
 TweakItem("Base.BF_EgenerexLite","DisplayCategory","Tool");
 TweakItem("Base.BF_SpiffoLite","DisplayCategory","Tool");
 TweakItem("Base.BF_OldFlashlight","DisplayCategory","Tool");
+end
+
 --BetterHelicopter
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2434548740
+if getActivatedMods():contains("Helicopter") then
 TweakItem("AI_HELI.HeliMag","DisplayCategory","LitR");
+end
+
 --BetterLockpicking
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2368058459
+if getActivatedMods():contains("betterLockpicking") then
 TweakItem("BetLock.LockpickingMag","DisplayCategory","LitR");
 TweakItem("BetLock.AlarmMag","DisplayCategory","LitR");
 TweakItem("BetLock.BobbyPin","DisplayCategory","Tool");
 TweakItem("BetLock.HandmadeBobbyPin","DisplayCategory","Tool");
+end
+
 --BetterTowing
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2241990680
+if getActivatedMods():contains("TowingCar") then
 TweakItem("TowingCar.TowBar","DisplayCategory","Tool");
+end
+
 --4ColorBicPen
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2753894806
+if getActivatedMods():contains("4ColorBicPen") then
 TweakItem("BicPen.BicPen","DisplayCategory","LitW");
+end
+
 --BogasPizza
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2675786278
+if getActivatedMods():contains("BogaPizza") then
 TweakItem("BogaPizza.PizzaDough","DisplayCategory","FoodP");
 TweakItem("BogaPizza.PizzaCheese","DisplayCategory","FoodP");
 TweakItem("BogaPizza.PizzaSauced","DisplayCategory","FoodP");
@@ -163,7 +232,11 @@ TweakItem("BogaPizza.RumHam","DisplayCategory","FoodP");
 TweakItem("BogaPizza.RumHamSlice","DisplayCategory","FoodP");
 TweakItem("BogaPizza.WhiteSauce","DisplayCategory","FoodN");
 TweakItem("BogaPizza.BBQSauce","DisplayCategory","FoodN");
+end
+
 --Books
+--???
+--if getActivatedMods():contains("???") then
 TweakItem("DBDA.DBDA1","DisplayCategory","LitE");
 TweakItem("DBDA.DBDA2","DisplayCategory","LitE");
 TweakItem("DBDA.DBDA3","DisplayCategory","LitE");
@@ -182,39 +255,74 @@ TweakItem("DBDA.Doc","DisplayCategory","LitE");
 TweakItem("DBDA.Out","DisplayCategory","LitE");
 TweakItem("DBDA.Who","DisplayCategory","LitE");
 TweakItem("DBDA.It","DisplayCategory","LitE");
+--end
+
 --CigaretteCartonMod
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2207313208
+if getActivatedMods():contains("2207313208") then
 TweakItem("CigaretteMod.CigarettesOne","DisplayCategory","Drugs");
 TweakItem("CigaretteMod.CigaretteCarton","DisplayCategory","Drugs");
+end
+
 --Computer
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2635550102
+if getActivatedMods():contains("Computer") 
+or getActivatedMods():contains("ComputerClassicsGamePack") 
+or getActivatedMods():contains("ComputerCorporalsGamePack") 
+or getActivatedMods():contains("ComputerGTAGamePack") then
 TweakItem("Computer.Disc_Game","DisplayCategory","MediaG");
+end
+
 --CoolBag
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2613596656
+if getActivatedMods():contains("CoolBag") then
 TweakItem("Base.WaterPocket","DisplayCategory","Tool");
 TweakItem("Base.IcePocket","DisplayCategory","Tool");
+end
+
 --CrashedCarsMod
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1539281445
+if getActivatedMods():contains("CrashedCarsMod") then
 TweakItem("Base.SmallTrunk0","DisplayCategory","Mechanics");
 TweakItem("Base.NormalTrunk0","DisplayCategory","Mechanics");
 TweakItem("Base.BigTrunk0","DisplayCategory","Mechanics");
 TweakItem("Base.FrontCarDoor0","DisplayCategory","Mechanics");
 TweakItem("Base.TrunkDoor0","DisplayCategory","Mechanics");
 TweakItem("Base.GloveBox0","DisplayCategory","Mechanics");
+end
+
 --Defecation
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1436878551
+if getActivatedMods():contains("Defecation") then
 TweakItem("Defecation.HumanFeces","DisplayCategory","SurFarm");
 TweakItem("Defecation.AntiDiarrhealPillBox","DisplayCategory","Medical");
 TweakItem("Defecation.AntiDiarrhealPill","DisplayCategory","Medical");
+end
+
 --Driving Skill
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2721945297
+if getActivatedMods():contains("DrivingSkill") then
 TweakItem("DrivingSkill.DrivingSkill_BookDriving1","DisplayCategory","LitS");
 TweakItem("DrivingSkill.DrivingSkill_BookDriving2","DisplayCategory","LitS");
 TweakItem("DrivingSkill.DrivingSkill_BookDriving3","DisplayCategory","LitS");
 TweakItem("DrivingSkill.DrivingSkill_BookDriving4","DisplayCategory","LitS");
 TweakItem("DrivingSkill.DrivingSkill_BookDriving5","DisplayCategory","LitS");
+end
+
 --EggonsFannyPackBalancing
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2276669022
+if getActivatedMods():contains("eggonsFannyPackBalancing") then
 TweakItem("Base.Bag_FannyPackFront","DisplayCategory","ClothB");
 TweakItem("Base.Bag_FannyPackBack","DisplayCategory","ClothB");
 TweakItem("Base.SportsFannyPack","DisplayCategory","ClothB");
 TweakItem("Base.SportsFannyPackBack","DisplayCategory","ClothB");
 TweakItem("Base.FannyPackXL","DisplayCategory","ClothB");
 TweakItem("Base.FannyPackXLBack","DisplayCategory","ClothB");
+end
+
 --EggonsSharpenYourBlades
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2656148564
+if getActivatedMods():contains("eggonsSharpenYourBlades") then
 TweakItem("ESYB.Sandstone","DisplayCategory","Tool");
 TweakItem("ESYB.HomemadeWhetstone","DisplayCategory","Tool");
 TweakItem("ESYB.Whetstone","DisplayCategory","Tool");
@@ -225,7 +333,11 @@ TweakItem("ESYB.MagazineTableGrinderUserManual","DisplayCategory","LitR");
 TweakItem("ESYB.MagazineJapaneseMastersSpecialEdition","DisplayCategory","LitR");
 TweakItem("ESYB.MagazineTypicalSharpeningMistakes","DisplayCategory","LitR");
 TweakItem("ESYB.MagazineHomemadeGrindingTools","DisplayCategory","LitR");
+end
+
 --EliazFitness&StrengthBooks
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2631394459
+if getActivatedMods():contains("EliazFitnessStrengthBooks") then
 TweakItem("Base.BookStrength1","DisplayCategory","LitS");
 TweakItem("Base.BookStrength2","DisplayCategory","LitS");
 TweakItem("Base.BookStrength3","DisplayCategory","LitS");
@@ -236,17 +348,34 @@ TweakItem("Base.BookFitness2","DisplayCategory","LitS");
 TweakItem("Base.BookFitness3","DisplayCategory","LitS");
 TweakItem("Base.BookFitness4","DisplayCategory","LitS");
 TweakItem("Base.BookFitness5","DisplayCategory","LitS");
+end
+
 --ExamineCorpses
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2523485011
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2692461764
+if getActivatedMods():contains("ExamineCorpses") or getActivatedMods():contains("ExamineCorpsesPLUS") then
 TweakItem("ExamineCorpse.nmMedicalMagazine1","DisplayCategory","LitR");
 TweakItem("ExamineCorpse.nmMedicalMagazine2","DisplayCategory","LitR");
 TweakItem("ExamineCorpse.nmMedicalStudiesJournal","DisplayCategory","Medical");
+end
+
 --Fencing Kits
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2812828771
+if getActivatedMods():contains("FencingKits") then
 TweakItem("FencingKit.FenceKit","DisplayCategory","CraftMetal");
 TweakItem("FencingKit.ChainWireRoll","DisplayCategory","CraftMetal");
+end
+
 --ForScience
+--???
+--if getActivatedMods():contains("???") then
 TweakItem("Base.BookMedicalJournal","DisplayCategory","LitS");
 TweakItem("Base.BookElectricManual","DisplayCategory","LitS");
+--end
+
 --Icecream-Maker
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2754525193
+if getActivatedMods():contains("icecreammaker") then
 TweakItem("icecreammaker.IceCreamChocolate","DisplayCategory","FoodP");
 TweakItem("icecreammaker.IceCreamStrawberry","DisplayCategory","FoodP");
 TweakItem("icecreammaker.IceCreamCaramel","DisplayCategory","FoodP");
@@ -263,7 +392,11 @@ TweakItem("icecreammaker.ConeStrawberry","DisplayCategory","FoodP");
 TweakItem("icecreammaker.ConeCaramel","DisplayCategory","FoodP");
 TweakItem("icecreammaker.ConeCookieDough","DisplayCategory","FoodP");
 TweakItem("icecreammaker.ConeCookiesCreme","DisplayCategory","FoodP");
+end
+
 --ImmersiveSolarArrays
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2623458493
+if getActivatedMods():contains("ISA") then
 TweakItem("ISA.SolarPanel","DisplayCategory","Electronics");
 TweakItem("ISA.ISAInverter","DisplayCategory","Electronics");
 TweakItem("ISA.DeepCycleBattery","DisplayCategory","Electronics");
@@ -278,7 +411,13 @@ TweakItem("ISA.SolarPanelWall","DisplayCategory","Electronics");
 TweakItem("ISA.SolarPanelMounted","DisplayCategory","Electronics");
 TweakItem("ISA.SolarFailsafe","DisplayCategory","Electronics");
 TweakItem("ISA.ISAMag1","DisplayCategory","LitR");
+end
+
 --KitsuneAmmoCraftBrita
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2753868915
+if getActivatedMods():contains("KACB") 
+or getActivatedMods():contains("KMMCB") 
+or getActivatedMods():contains("KMISCCB") then
 TweakItem("Base.Lyman49th_Manual","DisplayCategory","LitR");
 TweakItem("Base.Lyman_TMag","DisplayCategory","Tool");
 TweakItem("Base.Lee_LoadMaster","DisplayCategory","Tool");
@@ -296,7 +435,13 @@ TweakItem("Base.Lead556_Pack","DisplayCategory","CraftAmmo");
 TweakItem("Base.Lead545_Pack","DisplayCategory","CraftAmmo");
 TweakItem("Base.Lead30_Pack","DisplayCategory","CraftAmmo");
 TweakItem("Base.Lead00Buck_Pack","DisplayCategory","CraftAmmo");
+end
+
 --LactoseCrossbow
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1901390863
+if getActivatedMods():contains("LactoseCrossbow") 
+or getActivatedMods():contains("KCMcrossbowCompatibility") 
+or getActivatedMods():contains("Remastered Kitsune's Crossbow Mod Compatibility") then
 TweakItem("LactoseCrossbow.LCQuiver","DisplayCategory","Container");
 TweakItem("LactoseCrossbow.LCTestAttachment","DisplayCategory","Misc");
 TweakItem("LactoseCrossbow.CrossbowBolt","DisplayCategory","Ammo");
@@ -315,17 +460,29 @@ TweakItem("LactoseCrossbow.ModernCrossbowStrungSteel","DisplayCategory","WepBow"
 TweakItem("LactoseCrossbow.CrossbowStrungSteel","DisplayCategory","WepBow");
 TweakItem("LactoseCrossbow.ModernCrossbowStrungString","DisplayCategory","WepBow");
 TweakItem("LactoseCrossbow.ModernCrossbowStrungNylon","DisplayCategory","WepBow");
+end
+
 --Ladders
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2737665235
+if getActivatedMods():contains("Ladders") then
 TweakItem("Ladders.SteelLadder","DisplayCategory","Misc");
 TweakItem("Ladders.WoodenLadder","DisplayCategory","Misc");
+end
+
 --ManyBags
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2303814168
+if getActivatedMods():contains("MANYBAGS") then
 TweakItem("Base.AliceBackPack","DisplayCategory","ClothB");
 TweakItem("Base.AliceBackPackExtraPocket","DisplayCategory","ClothB");
 TweakItem("Base.AliceBackPackExtraPocket2","DisplayCategory","ClothB");
 TweakItem("Base.MilitaryAliceBackPack","DisplayCategory","ClothB");
 TweakItem("Base.MilitaryAliceBackPackExtraPocket","DisplayCategory","ClothB");
 TweakItem("Base.ExtraPocket","DisplayCategory","CraftTailor");
+end
+
 --MilitaryPonchos
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2629286881
+if getActivatedMods():contains("MilPoncho") then
 TweakItem("Base.MPonchoGreenUP","DisplayCategory","Cloth");
 TweakItem("Base.MPonchoGreenDOWN","DisplayCategory","Cloth");
 TweakItem("Base.MPonchoYellowUP","DisplayCategory","Cloth");
@@ -338,7 +495,11 @@ TweakItem("Base.MPonchoBlackUP","DisplayCategory","Cloth");
 TweakItem("Base.MPonchoBlackDOWN","DisplayCategory","Cloth");
 TweakItem("Base.MPonchoShoulderBLA","DisplayCategory","Cloth");
 TweakItem("Base.MPonchoShoulderBLAdown","DisplayCategory","Cloth");
+end
+
 --MoCropsMod
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2762018937
+if getActivatedMods():contains("MCM") then
 TweakItem("MCM.Avocadoseed","DisplayCategory","SurFarm");
 TweakItem("MCM.Pepperseed","DisplayCategory","SurFarm");
 TweakItem("MCM.Cornseed","DisplayCategory","SurFarm");
@@ -357,7 +518,13 @@ TweakItem("MCM.LettuceBagSeed","DisplayCategory","SurFarm");
 TweakItem("MCM.OnionBagSeed","DisplayCategory","SurFarm");
 TweakItem("MCM.WatermelonBagSeed","DisplayCategory","SurFarm");
 TweakItem("MCM.ZucchiniBagSeed","DisplayCategory","SurFarm");
+end
+
 --More Traits
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1299328280
+if getActivatedMods():contains("ToadTraits") 
+or getActivatedMods():contains("ToadTraitsDisablePrepared") 
+or getActivatedMods():contains("ToadTraitsDisableSpec") then
 TweakItem("MoreTraits.PackerBag","DisplayCategory","ClothB");
 TweakItem("MoreTraits.AntiqueAxe","DisplayCategory","WepMelee");
 TweakItem("MoreTraits.Thumper","DisplayCategory","Tool");
@@ -383,20 +550,32 @@ TweakItem("MoreTraits.Bag_SmallHikingBag","DisplayCategory","ClothB");
 TweakItem("MoreTraits.AntiqueSpear","DisplayCategory","WepMelee");
 TweakItem("MoreTraits.AntiqueHammer","DisplayCategory","Tool");
 TweakItem("MoreTraits.AntiqueKatana","DisplayCategory","WepMelee");
+end
+
 --PlayerTraps
+--https://steamcommunity.com/sharedfiles/filedetails/?id=710542108
+if getActivatedMods():contains("PlayerTraps") then
 TweakItem("Trap.PropaneTrap","DisplayCategory","SurTrap");
 TweakItem("Trap.BearTrap","DisplayCategory","SurTrap");
 TweakItem("Trap.BearTrapClosed","DisplayCategory","SurTrap");
 TweakItem("Trap.SpikeTrap","DisplayCategory","SurTrap");
 TweakItem("Trap.SpikeTrapClosed","DisplayCategory","SurTrap");
+end
+
 --PrimitiveSurvival
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1969674962
+if getActivatedMods():contains("PSurvival") then
 TweakItem("PrimitiveSurvival.PS_SheetBag","DisplayCategory","ClothB");
 TweakItem("PrimitiveSurvival.PS_PrimitiveBag","DisplayCategory","ClothB");
 TweakItem("PrimitiveSurvival.PS_BarkStrip","DisplayCategory","Craft");
 TweakItem("PrimitiveSurvival.PS_SmallRope","DisplayCategory","Craft");
 TweakItem("PrimitiveSurvival.PS_BranchesBundle","DisplayCategory","Craft");
 TweakItem("PrimitiveSurvival.PS_TwigsBundle","DisplayCategory","SurCamp");
+end
+
 --RaidioToGrid
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2001719506
+if getActivatedMods():contains("RadioToGrid") then
 TweakItem("rat.WalkieTalkie1Grid","DisplayCategory","Electronics");
 TweakItem("rat.WalkieTalkie2Grid","DisplayCategory","Electronics");
 TweakItem("rat.WalkieTalkie3Grid","DisplayCategory","Electronics");
@@ -409,20 +588,40 @@ TweakItem("rat.HamRadioMakeShiftGrid","DisplayCategory","Electronics");
 TweakItem("rat.RadioRedGrid","DisplayCategory","Electronics");
 TweakItem("rat.RadioBlackGrid","DisplayCategory","Electronics");
 TweakItem("rat.RadioMakeShiftGrid","DisplayCategory","Electronics");
+end
+
 --Scavenger Skill
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2721290568
+if getActivatedMods():contains("ScavengingSkill") then
 TweakItem("ScavengerSkill.ScavengerSkill_BookScavenging1","DisplayCategory","LitS");
 TweakItem("ScavengerSkill.ScavengerSkill_BookScavenging2","DisplayCategory","LitS");
 TweakItem("ScavengerSkill.ScavengerSkill_BookScavenging3","DisplayCategory","LitS");
 TweakItem("ScavengerSkill.ScavengerSkill_BookScavenging4","DisplayCategory","LitS");
 TweakItem("ScavengerSkill.ScavengerSkill_BookScavenging5","DisplayCategory","LitS");
+end
+
 --Silencer/Suppressor
+--https://steamcommunity.com/sharedfiles/filedetails/?id=639909479
+if getActivatedMods():contains("Silencer") then
 TweakItem("Silencer.Silencer","DisplayCategory","WepPart");
 TweakItem("Silencer.HMSilencer","DisplayCategory","WepPart");
+end
+
 --SimplePowderedMilk
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2698725395
+if getActivatedMods():contains("SimplePowderedMilk") then
 TweakItem("Base.fhqPowderedMilkPouch","DisplayCategory","FoodN");
+end
+
 --SkillRecoveryJournal
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2503622437
+if getActivatedMods():contains("SkillRecoveryJournal") then
 TweakItem("Base.SkillRecoveryJournal","DisplayCategory","LitS");
+end
+
 --SleepingBags
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2714848168
+if getActivatedMods():contains("PwSleepingbags") then
 TweakItem("Base.Sleepingbag","DisplayCategory","SurCamp");
 TweakItem("Base.SleepingbagG","DisplayCategory","SurCamp");
 TweakItem("Base.SleepingbagR","DisplayCategory","SurCamp");
@@ -437,12 +636,20 @@ TweakItem("Base.SleepingbagORolled","DisplayCategory","SurCamp");
 TweakItem("Base.SleepingbagBKRolled","DisplayCategory","SurCamp");
 TweakItem("Base.SleepingbagLBRolled","DisplayCategory","SurCamp");
 TweakItem("Base.SleepingbagPRolled","DisplayCategory","SurCamp");
+end
+
 --SlingModFix
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2684045242
+if getActivatedMods():contains("SlingModFix") then
 TweakItem("Base.SlingA","DisplayCategory","ClothA");
 TweakItem("Base.SlingAalt","DisplayCategory","ClothA");
 TweakItem("Base.SlingAalt2","DisplayCategory","ClothA");
 TweakItem("Base.SlingAalt3","DisplayCategory","ClothA");
+end
+
 --SmokinJoesSmokes
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2772023775
+if getActivatedMods():contains("smokinjoessmokes") then
 TweakItem("Base.PackOfSmokes","DisplayCategory","Drugs");
 TweakItem("Base.CartonOfSmokes","DisplayCategory","Drugs");
 TweakItem("Base.Cigarettes","DisplayCategory","Drugs");
@@ -455,7 +662,11 @@ TweakItem("Base.PlasticLighter_Orange","DisplayCategory","Tool");
 TweakItem("Base.PlasticLighter_Purple","DisplayCategory","Tool");
 TweakItem("Base.PlasticLighter_Red","DisplayCategory","Tool");
 TweakItem("Base.PlasticLighter_Yellow","DisplayCategory","Tool");
+end
+
 --SprayPaint
+--https://steamcommunity.com/sharedfiles/filedetails/?id=499153179
+if getActivatedMods():contains("spraypaintEDIT") then
 TweakItem("spraypaint.SpraycanWhite","DisplayCategory","Tool");
 TweakItem("spraypaint.SpraycanRed","DisplayCategory","Tool");
 TweakItem("spraypaint.SpraycanBlue","DisplayCategory","Tool");
@@ -473,7 +684,11 @@ TweakItem("spraypaint.ChalkOrange","DisplayCategory","Tool");
 TweakItem("spraypaint.ChalkYellow","DisplayCategory","Tool");
 TweakItem("spraypaint.ChalkViolet","DisplayCategory","Tool");
 TweakItem("spraypaint.ChalkCyan","DisplayCategory","Tool");
+end
+
 --SpongiesClothing
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2684285534
+if getActivatedMods():contains("SpnCloth") or getActivatedMods():contains("SpnClothVanilla") then
 TweakItem("Spongie.Gloves_StripedLong","DisplayCategory","Cloth");
 TweakItem("Spongie.Jacket_SheepWool","DisplayCategory","Cloth");
 TweakItem("Spongie.Jacket_SheepWoolOPEN","DisplayCategory","Cloth");
@@ -491,7 +706,13 @@ TweakItem("Spongie.Vest_Waterproof","DisplayCategory","Cloth");
 TweakItem("Spongie.Jumper_Military","DisplayCategory","Cloth");
 TweakItem("Spongie.Shorts_Spandex","DisplayCategory","Cloth");
 TweakItem("Spongie.Shorts_SpandexLong","DisplayCategory","Cloth");
+end
+
 --Treads Water Tank Trucks
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2719592131
+if getActivatedMods():contains("RS_WaterCistern") 
+or getActivatedMods():contains("RS_WaterCistern_FR_Overwrite") 
+or getActivatedMods():contains("RS_WaterCistern_KI5_Addon") then
 TweakItem("Base.1500_Water_Tank1","DisplayCategory","Mechanics");
 TweakItem("Base.1500_Water_Tank2","DisplayCategory","Mechanics");
 TweakItem("Base.1500_Water_Tank3","DisplayCategory","Mechanics");
@@ -505,12 +726,20 @@ TweakItem("Base.3000_Water_Tank_Tainted1","DisplayCategory","Mechanics");
 TweakItem("Base.3000_Water_Tank_Tainted2","DisplayCategory","Mechanics");
 TweakItem("Base.3000_Water_Tank_Tainted3","DisplayCategory","Mechanics");
 TweakItem("Base.RS_WaterFilter","DisplayCategory","Mechanics");
+end
+
 --TheyKnew
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2725378876
+if getActivatedMods():contains("TheyKnew") then
 TweakItem("TheyKnew.Zomboxycycline","DisplayCategory","Medical");
 TweakItem("TheyKnew.Zomboxivir","DisplayCategory","Medical");
 TweakItem("TheyKnew.MysteriousHazmat","DisplayCategory","Cloth");
 TweakItem("TheyKnew.MysteriousSatchel","DisplayCategory","ClothB");
+end
+
 --UndeadSurvivor
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2713921292
+if getActivatedMods():contains("UndeadSuvivor") then
 TweakItem("UndeadSurvivor.PrepperFlashlight","DisplayCategory","Tool");
 TweakItem("UndeadSurvivor.PrepperMask","DisplayCategory","Cloth");
 TweakItem("UndeadSurvivor.PrepperHelmet","DisplayCategory","Cloth");
@@ -541,7 +770,11 @@ TweakItem("UndeadSurvivor.OminousNomadMask","DisplayCategory","Cloth");
 TweakItem("UndeadSurvivor.NomadBoots","DisplayCategory","Cloth");
 TweakItem("UndeadSurvivor.NomadTrousers","DisplayCategory","Cloth");
 TweakItem("UndeadSurvivor.NomadTrousersTucked","DisplayCategory","Cloth");
+end
+
 --USMCArmory
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2611652130
+if getActivatedMods():contains("DRK_1") then
 TweakItem("Base.Interceptor_Armor","DisplayCategory","Cloth");
 TweakItem("Base.Interceptor_Armor_s","DisplayCategory","Cloth");
 TweakItem("Base.Interceptor_Armor_v","DisplayCategory","Cloth");
@@ -555,9 +788,17 @@ TweakItem("Base.Hat_PASGT_Helmet","DisplayCategory","Cloth");
 TweakItem("Base.Hat_TPASGT_Helmet","DisplayCategory","Cloth");
 TweakItem("Base.Interceptor_Pouches","DisplayCategory","Container");
 TweakItem("Base.Interceptor_Pouches_Straps","DisplayCategory","Container");
+end
+
 --Vehicle Repair Overhaul
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2757712197
+if getActivatedMods():contains("VehicleRepairOverhaul") then
 TweakItem("FixAFlat.FixAFlat","DisplayCategory","Tool");
+end
+
 --W900Semi-Truck
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2759339330
+if getActivatedMods():contains("rSemiTruck") then
 TweakItem("RotatorsClothing.Hat_BaseballCapRotators","DisplayCategory","Cloth");
 TweakItem("RotatorsClothing.Hat_BaseballCapRotators_Reverse","DisplayCategory","Cloth");
 TweakItem("Rotators.750Tank2","DisplayCategory","Mechanics");
@@ -571,26 +812,46 @@ TweakItem("Rotators.SemiTruckBullbar_Item2","DisplayCategory","Mechanics");
 TweakItem("Rotators.SemiTruckArmorDoor_Item2","DisplayCategory","Mechanics");
 TweakItem("Rotators.SemiTruckArmorFront_Item2","DisplayCategory","Mechanics");
 TweakItem("Rotators.SemiTruckArmorRear_Item2","DisplayCategory","Mechanics");
+end
+
 --WaterDispenser
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2687798127
+if getActivatedMods():contains("WaterDispenser") then
 TweakItem("WaterDispenser.WaterJugEmpty","DisplayCategory","Container");
 TweakItem("WaterDispenser.WaterJugWaterFull","DisplayCategory","Container");
 TweakItem("WaterDispenser.WaterJugPetrolFull","DisplayCategory","Fuel");
+end
+
 --WaterPipes
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2464581798
+if getActivatedMods():contains("waterPipes") then
 TweakItem("Waterpipes.WaterPipe","DisplayCategory","SurFarm");
+end
+
 --WaterTrailer
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2732639855
+if getActivatedMods():contains("rWaterTrailer") or getActivatedMods():contains("rWaterTrailerSemi") then
 TweakItem("RotatorsClothing.TShirt_RotatorsBlack","DisplayCategory","Cloth");
 TweakItem("Rotators.WaterTrailerTankLid1","DisplayCategory","Mechanics");
 TweakItem("Rotators.WaterTrailerTankLid2","DisplayCategory","Mechanics");
 TweakItem("Rotators.WaterTrailerTankPump1","DisplayCategory","Mechanics");
 TweakItem("Rotators.WaterTrailerTankPump2","DisplayCategory","Mechanics");
 TweakItem("Rotators.WaterTrailerTankFilter2","DisplayCategory","Mechanics");
+end
+
 --WildFruits
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2618566294
+if getActivatedMods():contains("MattSimpleAddonsFriuts") then
 TweakItem("MattSimpleAddons.MSABlack_Cherry","DisplayCategory","FoodP");
 TweakItem("MattSimpleAddons.MSAmerican_Plumb","DisplayCategory","FoodP");
 TweakItem("MattSimpleAddons.MSARaspberries","DisplayCategory","FoodP");
 TweakItem("MattSimpleAddons.MSABlackBerries","DisplayCategory","FoodP");
 TweakItem("MattSimpleAddons.MSAMulberry","DisplayCategory","FoodP");
+end
+
 --Xnertot Farmable Trees
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2542052721
+if getActivatedMods():contains("XnerTree") then
 TweakItem("XNTree.XNSaplingApple","DisplayCategory","SurFarm");
 TweakItem("XNTree.XNSaplingBanana","DisplayCategory","SurFarm");
 TweakItem("XNTree.XNSaplingCherry","DisplayCategory","SurFarm");
@@ -598,3 +859,4 @@ TweakItem("XNTree.XNSaplingLemon","DisplayCategory","SurFarm");
 TweakItem("XNTree.XNSaplingOrange","DisplayCategory","SurFarm");
 TweakItem("XNTree.XNSaplingPeach","DisplayCategory","SurFarm");
 TweakItem("XNTree.XNSaplingPineapple","DisplayCategory","SurFarm");
+end

--- a/media/lua/client/Mod Support/Smoker_Items.lua
+++ b/media/lua/client/Mod Support/Smoker_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --SMOKER
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2026976958
+if getActivatedMods():contains("Smoker") then
 TweakItem("SM.SMPack","DisplayCategory","Drugs")
 TweakItem("SM.SMPackLight","DisplayCategory","Drugs")
 TweakItem("SM.SMPackGold","DisplayCategory","Drugs")
@@ -52,3 +54,4 @@ TweakItem("SM.SMHandfulTobacco","DisplayCategory","Craft")
 TweakItem("SM.SMPileTobacco","DisplayCategory","Craft")
 TweakItem("SM.SMBigPileTobacco","DisplayCategory","Craft")
 TweakItem("SM.SMSmokingBlend","DisplayCategory","Craft")
+end

--- a/media/lua/client/Mod Support/SnakesModPack_Items.lua
+++ b/media/lua/client/Mod Support/SnakesModPack_Items.lua
@@ -1,7 +1,10 @@
 require("ItemTweaker_Copy_CC");
 
 --SnakesModPack
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2719327441
+
 --AliceBackpack5
+if getActivatedMods():contains("AliceSPack") then
 TweakItem("AliceBP.SpearMilitaryKnife","DisplayCategory","WepMelee");
 TweakItem("AliceBP.SupportBackpack","DisplayCategory","ClothB");
 TweakItem("AliceBP.MRE","DisplayCategory","FoodN");
@@ -21,7 +24,10 @@ TweakItem("AliceBP.MilitaryCanteenFull","DisplayCategory","FoodB");
 TweakItem("AliceBP.MilitaryKnife","DisplayCategory","WepMelee");
 TweakItem("AliceBP.AlicePackUrban","DisplayCategory","ClothB");
 TweakItem("AliceBP.AlicePackDesert","DisplayCategory","ClothB");
+end
+
 --AmmoMakerReloaded
+if getActivatedMods():contains("AmmoMaker") then
 TweakItem("Base.Tshirt_AmmoMakerGreen","DisplayCategory","Cloth");
 TweakItem("AmmoMaker.ManualAM","DisplayCategory","LitR");
 TweakItem("AmmoMaker.AMBookAReloading1","DisplayCategory","LitS");
@@ -156,22 +162,37 @@ TweakItem("AmmoMaker.AmmoMagazine11","DisplayCategory","LitR");
 TweakItem("AmmoMaker.AmmoMagazine12","DisplayCategory","LitR");
 TweakItem("AmmoMaker.AmmoMagazine13","DisplayCategory","LitR");
 TweakItem("AmmoMaker.AmmoMagazine14","DisplayCategory","LitR");
+end
+
 --BatsMetalIconsRevived
+if getActivatedMods():contains("BatesMetalicosRevived") then
 TweakItem("BatesMetalicos.Bgrip","DisplayCategory","WepPart");
 TweakItem("BatesMetalicos.Bsock","DisplayCategory","WepPart");
 TweakItem("BatesMetalicos.MetalBaseballBat","DisplayCategory","WepMelee");
+end
+
 --FuelTanksMod
+if getActivatedMods():contains("FuelTanksMod") then
 TweakItem("FuelTanks.FuelTanksMag1","DisplayCategory","LitR");
 TweakItem("FuelTanks.FuelMeter","DisplayCategory","Tool");
+end
+
 --MilitaryComplex
+if getActivatedMods():contains("MilitaryComplex") then
 TweakItem("Base.MilitaryComplexMap","DisplayCategory","Map");
+end
+
 --RiversideGunstore
+if getActivatedMods():contains("Riverside Gunstore") then
 TweakItem("Base.Shoes_BowlingTrainers","DisplayCategory","Cloth");
 TweakItem("Base.Shoes_BowlingTrainersRed","DisplayCategory","Cloth");
 TweakItem("Base.Shoes_BowlingTrainersGreen","DisplayCategory","Cloth");
 TweakItem("Base.Bowlingball","DisplayCategory","WepMelee");
 TweakItem("Base.BowlingPin","DisplayCategory","WepMelee");
+end
+
 --SkillsMag
+if getActivatedMods():contains("SkillsMag") then
 TweakItem("SkillMag.SkillMagPackage","DisplayCategory","LitS");
 TweakItem("SkillMag.SkillMagSprint","DisplayCategory","LitS");
 TweakItem("SkillMag.SkillMagLightFoot","DisplayCategory","LitS");
@@ -197,7 +218,10 @@ TweakItem("SkillMag.SkillMagMaintenance","DisplayCategory","LitS");
 TweakItem("SkillMag.SkillMagTailor","DisplayCategory","LitS");
 TweakItem("SkillMag.SkillMagAmmoReloading","DisplayCategory","LitS");
 TweakItem("SkillMag.SkillMagHunting","DisplayCategory","LitS");
+end
+
 --SnakeClothingMod
+if getActivatedMods():contains("SnakeClothingMod") then
 TweakItem("Base.CowToy","DisplayCategory","Junk");
 TweakItem("Base.SafeToy","DisplayCategory","Junk");
 TweakItem("Base.HorseToy","DisplayCategory","Junk");
@@ -222,7 +246,10 @@ TweakItem("Base.Hat_BarcelonaCap_Reverse","DisplayCategory","Cloth");
 TweakItem("Base.DitoHoodieDOWN_WhiteTINT","DisplayCategory","Cloth");
 TweakItem("Base.DitoHoodieUP_WhiteTINT","DisplayCategory","Cloth");
 TweakItem("Base.AlicePackDito","DisplayCategory","ClothB");
+end
+
 --SnakeMansion
+if getActivatedMods():contains("SnakeMansion") then
 TweakItem("Base.RouletteStick","DisplayCategory","WepMelee");
 TweakItem("Base.ZMChip1","DisplayCategory","Junk");
 TweakItem("Base.ZMChip2","DisplayCategory","Junk");
@@ -233,7 +260,10 @@ TweakItem("Base.ZMChip6","DisplayCategory","Junk");
 TweakItem("Base.ZMChip7","DisplayCategory","Junk");
 TweakItem("Base.ZMChip8","DisplayCategory","Junk");
 TweakItem("Base.ZMChip9","DisplayCategory","Junk");
+end
+
 --TableSaw
+if getActivatedMods():contains("TableSaw") then
 TweakItem("ColorDyes.DyesMag","DisplayCategory","LitR");
 TweakItem("ColorDyes.PlantRed","DisplayCategory","Paint");
 TweakItem("ColorDyes.PlantYellow","DisplayCategory","Paint");
@@ -321,7 +351,10 @@ TweakItem("TableSaw.StickStacks","DisplayCategory","CraftCarp");
 TweakItem("TableSaw.PlankStacks1","DisplayCategory","CraftCarp");
 TweakItem("TableSaw.PlankStacks2","DisplayCategory","CraftCarp");
 TweakItem("TableSaw.PlankStacks3","DisplayCategory","CraftCarp");
+end
+
 --TallerMecanico
+if getActivatedMods():contains("TallerMecanico") then
 TweakItem("Base.BatteryCleaner","DisplayCategory","Tool");
 TweakItem("Base.CarVanTunningParts","DisplayCategory","Mechanics");
 TweakItem("Base.CarStepVanTunningParts","DisplayCategory","Mechanics");
@@ -355,7 +388,10 @@ TweakItem("Base.SuspensionParts","DisplayCategory","Mechanics");
 TweakItem("Base.BrakesParts","DisplayCategory","Mechanics");
 TweakItem("Base.BrakesPartsBox","DisplayCategory","Mechanics");
 TweakItem("Base.SuspensionPartsBag","DisplayCategory","Mechanics");
+end
+
 --WPA
+if getActivatedMods():contains("WPA") then
 TweakItem("WPA.SilencerRK","DisplayCategory","Tool");
 TweakItem("WPA.SpongeTube","DisplayCategory","Tool");
 TweakItem("WPA.WeaponsMagazine","DisplayCategory","LitR");
@@ -435,3 +471,4 @@ TweakItem("WPA.SRecoilCompensator","DisplayCategory","WepPart");
 TweakItem("WPA.ShellHolderStock","DisplayCategory","WepPart");
 TweakItem("WPA.ShotgunPolymerStock","DisplayCategory","WepPart");
 TweakItem("WPA.FoldingStock","DisplayCategory","WepPart");
+end

--- a/media/lua/client/Mod Support/SoulFilchers_Items.lua
+++ b/media/lua/client/Mod Support/SoulFilchers_Items.lua
@@ -2,6 +2,8 @@ require "ItemTweaker_Copy_CC"
 --Courtesy of Baldovino98
 
 --BeautifyingTime
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2425267353
+if getActivatedMods():contains("BeautifyingTime") or getActivatedMods():contains("SoulFilchersBeautifyingTime") then
 TweakItem("filcher.HairDyeAuburn","DisplayCategory","Appear");
 TweakItem("filcher.HairDyeAvocado","DisplayCategory","Appear");
 TweakItem("filcher.HairDyeCherry","DisplayCategory","Appear");
@@ -20,7 +22,11 @@ TweakItem("filcher.HairDyeOrange","DisplayCategory","Appear");
 TweakItem("filcher.HairDyePurple","DisplayCategory","Appear");
 TweakItem("filcher.HairDyeSnowWhite","DisplayCategory","Appear");
 TweakItem("filcher.HairDyeTurquoise","DisplayCategory","Appear");
+end
+
 --BuildingTime
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2324586266
+if getActivatedMods():contains("BuildingTime") or getActivatedMods():contains("SoulFilchersBuildingTime") then
 TweakItem("filcher.SFChisel","DisplayCategory","Tool");
 TweakItem("filcher.MasonsTrowel","DisplayCategory","Tool");
 TweakItem("filcher.BookMasonry1","DisplayCategory","LitS");
@@ -39,7 +45,11 @@ TweakItem("filcher.HandTruckRed","DisplayCategory","Tool");
 TweakItem("filcher.SFMoldedBricks","DisplayCategory","CraftMas");
 TweakItem("filcher.SFSealant","DisplayCategory","CraftMas");
 TweakItem("filcher.SFGlassPanel","DisplayCategory","CraftMas");
+end
+
 --ClearingTime
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1926311864
+if getActivatedMods():contains("ClearingTime") or getActivatedMods():contains("SoulFilchersClearingTime") then
 TweakItem("filcher.NailGun","DisplayCategory","WepRange");
 TweakItem("filcher.PoolballInSock","DisplayCategory","WepMelee");
 TweakItem("filcher.Recorder","DisplayCategory","WepMelee");
@@ -48,7 +58,11 @@ TweakItem("filcher.ClosedUmbrellaPink","DisplayCategory","WepMelee");
 TweakItem("filcher.WalkingCane","DisplayCategory","WepMelee");
 TweakItem("filcher.WoodenCross","DisplayCategory","WepMelee");
 TweakItem("Base.Corkscrew","DisplayCategory","WepMelee");
+end
+
 --CookingTime
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1910606509
+if getActivatedMods():contains("CookingTime") or getActivatedMods():contains("SoulFilchersCookingTime") then
 TweakItem("filcher.SFCookingMag1","DisplayCategory","LitR");
 TweakItem("filcher.SFCookingMag2","DisplayCategory","LitR");
 TweakItem("filcher.SFCookingMag3","DisplayCategory","LitR");
@@ -145,7 +159,11 @@ TweakItem("filcher.SFCupcakeTray","DisplayCategory","Cooking");
 TweakItem("filcher.EmptyGlass","DisplayCategory","Cooking");
 TweakItem("filcher.JarAndLid","DisplayCategory","Cooking");
 TweakItem("filcher.SFThinStick","DisplayCategory","Cooking");
+end
+
 --DressingTime
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2296517419
+if getActivatedMods():contains("DressingTime") or getActivatedMods():contains("SoulFilchersDressingTime") then
 TweakItem("MoreSkillBooks.Bag_FannyPackTINTFront","DisplayCategory","ClothB");
 TweakItem("MoreSkillBooks.Bag_FannyPackTINTBack","DisplayCategory","ClothB");
 TweakItem("MoreSkillBooks.Bag_NormalHikingBagTINT","DisplayCategory","ClothB");
@@ -248,7 +266,11 @@ TweakItem("MoreSkillBooks.Shoes_Clown","DisplayCategory","Cloth");
 TweakItem("MoreSkillBooks.Shoes_SantaBoots","DisplayCategory","Cloth");
 TweakItem("MoreSkillBooks.Socks_Ballet","DisplayCategory","Cloth");
 TweakItem("MoreSkillBooks.Socks_StockingsBlack","DisplayCategory","Cloth");
+end
+
 --DrinkingTime
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2578460720
+if getActivatedMods():contains("DrinkingTime") or getActivatedMods():contains("SoulFilchersDrinkingTime") then
 TweakItem("filcher.JarWater","DisplayCategory","FoodB");
 TweakItem("filcher.PetrolCanWater","DisplayCategory","FoodB");
 TweakItem("filcher.PopCanWater","DisplayCategory","FoodB");
@@ -259,7 +281,11 @@ TweakItem("filcher.TinCanWater","DisplayCategory","FoodB");
 TweakItem("filcher.WaterDishFull","DisplayCategory","FoodB");
 TweakItem("filcher.WaterGallon","DisplayCategory","FoodB");
 TweakItem("filcher.WaterGallonEmpty","DisplayCategory","Container");
+end
+
 --ExploringTime
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2244879881
+if getActivatedMods():contains("ExploringTime") or getActivatedMods():contains("SoulFilchersExploringTime") then
 TweakItem("filcher.BottleWithGasPop","DisplayCategory","Fuel");
 TweakItem("filcher.BottleWithGasWater","DisplayCategory","Fuel");
 TweakItem("filcher.Flare","DisplayCategory","Tool");
@@ -274,7 +300,11 @@ TweakItem("filcher.TorchPlank","DisplayCategory","Tool");
 TweakItem("filcher.TorchPlankLit","DisplayCategory","Tool");
 TweakItem("filcher.TorchTableLeg","DisplayCategory","Tool");
 TweakItem("filcher.TorchTableLegLit","DisplayCategory","Tool");
+end
+
 --FarmingTime
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1915420850
+if getActivatedMods():contains("FarmingTime") or getActivatedMods():contains("SoulFilchersFarmingTime") then
 TweakItem("filcher.SFBeetSyrupPot","DisplayCategory","FoodN");
 TweakItem("filcher.SFBeetPot","DisplayCategory","FoodN");
 TweakItem("filcher.Beetroot","DisplayCategory","FoodP");
@@ -300,7 +330,11 @@ TweakItem("filcher.GardeningSprayMilk","DisplayCategory","SurFarm");
 TweakItem("filcher.SFGrainGrinder","DisplayCategory","Tool");
 TweakItem("filcher.SFCloth","DisplayCategory","Junk");
 TweakItem("filcher.SFClothDirty","DisplayCategory","Junk");
+end
+
 --ForagingTime
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2677920531
+if getActivatedMods():contains("ForagingTime") or getActivatedMods():contains("SoulFilchersForagingTime") then
 TweakItem("filcher.SFAcorns","DisplayCategory","FoodN");
 TweakItem("filcher.SFHickoryNut","DisplayCategory","FoodN");
 TweakItem("filcher.SFHoney","DisplayCategory","FoodN");
@@ -312,7 +346,11 @@ TweakItem("filcher.SFRaspberry","DisplayCategory","FoodP");
 TweakItem("filcher.SFTruffles","DisplayCategory","FoodP");
 TweakItem("filcher.Cigarette","DisplayCategory","Drugs");
 TweakItem("filcher.SFDeadCrow","DisplayCategory","FoodP");
+end
+
 --FreezingTime
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2779902452
+if getActivatedMods():contains("FreezingTime") or getActivatedMods():contains("SoulFilchersFreezingTime") then
 TweakItem("filcher.SFBucketSnow","DisplayCategory","Craft");
 TweakItem("filcher.SFEmptyTray","DisplayCategory","Container");
 TweakItem("filcher.SFIceTray","DisplayCategory","FoodB");
@@ -323,7 +361,11 @@ TweakItem("filcher.SFThermometer","DisplayCategory","Junk");
 TweakItem("filcher.TinCanSnow","DisplayCategory","Craft");
 TweakItem("filcher.TinCanWater","DisplayCategory","FoodB");
 TweakItem("filcher.SFWaterTray","DisplayCategory","FoodB");
+end
+
 --LearningTime
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1911229825
+if getActivatedMods():contains("LearningTime") or getActivatedMods():contains("SoulFilchersLearningTime") then
 TweakItem("filcher.BookMaintenance1","DisplayCategory","LitR");
 TweakItem("filcher.BookMaintenance2","DisplayCategory","LitR");
 TweakItem("filcher.BookMaintenance3","DisplayCategory","LitR");
@@ -374,7 +416,11 @@ TweakItem("filcher.SmithingNotes2","DisplayCategory","LitR");
 TweakItem("filcher.SmithingNotes3","DisplayCategory","LitR");
 TweakItem("filcher.SmithingNotes4","DisplayCategory","LitR");
 TweakItem("filcher.SmithingNotes5","DisplayCategory","LitR");
+end
+
 --RelaxingTime
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2039234811
+if getActivatedMods():contains("RelaxingTime") or getActivatedMods():contains("SoulFilchersRelaxingTime") then
 TweakItem("filcher.ColoringBook","DisplayCategory","LitE");
 TweakItem("filcher.Crosswords","DisplayCategory","LitE");
 TweakItem("filcher.GiftCard","DisplayCategory","Junk");
@@ -390,7 +436,11 @@ TweakItem("filcher.SFChessboard","DisplayCategory","Junk");
 TweakItem("filcher.SFLetter","DisplayCategory","Junk");
 TweakItem("filcher.Magic8Ball","DisplayCategory","Junk");
 TweakItem("filcher.MulticolorPen","DisplayCategory","LitW");
+end
+
 --PhotographingTime
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2810116138
+if getActivatedMods():contains("PhotographingTime") or getActivatedMods():contains("SoulFilchersPhotographingTime") then
 TweakItem("Base.CameraReady","DisplayCategory","Electronics");
 TweakItem("Base.CameraDisposable","DisplayCategory","Electronics");
 TweakItem("Base.CameraExpensiveReady","DisplayCategory","Electronics");
@@ -404,3 +454,4 @@ TweakItem("Base.BookPhotography2","DisplayCategory","LitS");
 TweakItem("Base.BookPhotography3","DisplayCategory","LitS");
 TweakItem("Base.BookPhotography4","DisplayCategory","LitS");
 TweakItem("Base.BookPhotography5","DisplayCategory","LitS");
+end

--- a/media/lua/client/Mod Support/Swatpackredux_Items.lua
+++ b/media/lua/client/Mod Support/Swatpackredux_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --SWATPACKREDUX
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2091564445
+if getActivatedMods():contains("Swatpack") then
 TweakItem("Base.SWATPad","DisplayCategory","Cloth");
 TweakItem("Base.SwatNeck","DisplayCategory","Cloth");
 TweakItem("Base.Hat_SwatGasMask","DisplayCategory","Cloth");
@@ -37,3 +39,4 @@ TweakItem("Base.9mmMp5Clip","DisplayCategory","Ammo");
 TweakItem("Base.SwatStunGrenade","DisplayCategory","WepBomb");
 TweakItem("Base.SwatFragGrenade","DisplayCategory","WepBomb");
 TweakItem("Base.SwatSmokeGrenade","DisplayCategory","WepBomb");
+end

--- a/media/lua/client/Mod Support/TrueMusicAddonMod_Items.lua
+++ b/media/lua/client/Mod Support/TrueMusicAddonMod_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --SpiffosTrueMusic
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2723341089
+if getActivatedMods():contains("SpiffoTrueMusic") then
 TweakItem("Tsarcraft.Cassette2pacIGetAround(1993)","DisplayCategory","MediaA");
 TweakItem("Tsarcraft.CassetteahaTakeonMe(1985)","DisplayCategory","MediaA");
 TweakItem("Tsarcraft.CassetteABBADancingQueen(1976)","DisplayCategory","MediaA");
@@ -411,3 +413,4 @@ TweakItem("Tsarcraft.VinylVillagePeopleReadyForThe80's(1979)","DisplayCategory",
 TweakItem("Tsarcraft.VinylVillagePeopleYMCA(1978)","DisplayCategory","MediaA");
 TweakItem("Tsarcraft.VinylWhitneyHoustonIWillAlwaysLoveYou(1992)","DisplayCategory","MediaA");
 TweakItem("Tsarcraft.VinylYesRoundabout(1971)","DisplayCategory","MediaA");
+end

--- a/media/lua/client/Mod Support/TsarMods_Items.lua
+++ b/media/lua/client/Mod Support/TsarMods_Items.lua
@@ -1,13 +1,19 @@
 require("ItemTweaker_Copy_CC")
 
 --Agrotsar
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2728257015
+if getActivatedMods():contains("agrotsar") then
 TweakItem("Agrotsar.AgrotsarMag","DisplayCategory","LitR");
 TweakItem("Agrotsar.ASeederTankSmall","DisplayCategory","Mechanics");
 TweakItem("Agrotsar.ASeederTankMedium","DisplayCategory","Mechanics");
 TweakItem("Agrotsar.ASeederTankLarge","DisplayCategory","Mechanics");
 TweakItem("Agrotsar.ASeederPlate","DisplayCategory","Mechanics");
 TweakItem("Agrotsar.APlowshare","DisplayCategory","Mechanics");
+end
+
 --ATA_BUS
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2592358528
+if getActivatedMods():contains("ATA_Bus") then
 TweakItem("Autotsar.AtTuningMagBus","DisplayCategory","LitR");
 TweakItem("Autotsar.ATA_Bus_Roof_Rack","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATA_Bus_Roof_Box_Item","DisplayCategory","Mechanics");
@@ -22,7 +28,13 @@ TweakItem("Autotsar.ATA_Bus_Protection_wheels_Item","DisplayCategory","Mechanics
 TweakItem("Autotsar.ATA_Bus_Protection_windows_front_Item","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATA_Bus_Protection_windows_right_Item","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATA_Bus_Protection_windows_left_Item","DisplayCategory","Mechanics");
+end
+
 --ATA-Fjord
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2681635926
+if getActivatedMods():contains("ATA_Mustang") 
+or getActivatedMods():contains("ATA_Mustang_x2") 
+or getActivatedMods():contains("ATA_Mustang_x4") then
 TweakItem("Autotsar.ATATuningFordMustang","DisplayCategory","LitR");
 TweakItem("Autotsar.ATAMustangBullbar1Item","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAMustangBullbar2Item","DisplayCategory","Mechanics");
@@ -40,7 +52,14 @@ TweakItem("Autotsar.ATAMustangProtectionWindowRightItem","DisplayCategory","Mech
 TweakItem("Autotsar.ATAMustangProtectionWindowFrontItem","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAMustangProtectionWindowRearItem","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAMustangRoofRackItem","DisplayCategory","Mechanics");
+end
+
 --ATA-JAAP
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2636100523
+if getActivatedMods():contains("ATA_Jeep") 
+or getActivatedMods():contains("ATA_Jeep_x2") 
+or getActivatedMods():contains("ATA_Jeep_x4") 
+or getActivatedMods():contains("ATA_Jeep_x10") then
 TweakItem("Autotsar.AtTuningMagJeep","DisplayCategory","LitR");
 TweakItem("Autotsar.ATAJeepBumper1Item","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAJeepBumper2Item","DisplayCategory","Mechanics");
@@ -54,7 +73,11 @@ TweakItem("Autotsar.ATAJeepInteractiveTrunkRoofRackItem","DisplayCategory","Mech
 TweakItem("Autotsar.ATAJeepInteractiveTrunkWheelRackItem","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAJeepRoofTentItem","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAJeepSnorkelItem","DisplayCategory","Mechanics");
+end
+
 --ATA-Dadge
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2743496289
+if getActivatedMods():contains("ATA_Dadge") then
 TweakItem("Autotsar.ATADodgeTuningMag","DisplayCategory","LitR");
 TweakItem("Autotsar.ATADodgeRoofRackItem","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATADodgeWindowRackItem","DisplayCategory","Mechanics");
@@ -63,7 +86,11 @@ TweakItem("Autotsar.ATADodgeBullbar2Item","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATADodgeBullbar3Item","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATADodgeProtectionWindowSideItem","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATADodgeProtectionWindowFrontItem","DisplayCategory","Mechanics");
+end
+
 --ATA-Petyarbuilt
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2782258356
+if getActivatedMods():contains("ATA_Petyarbuilt") then
 TweakItem("Autotsar.ATAPetyarbuiltTuningMag","DisplayCategory","LitR");
 TweakItem("Autotsar.ATAPetyarbuiltProtectionSleeperItem","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAPetyarbuiltProtectionRearWheelsItem","DisplayCategory","Mechanics");
@@ -72,7 +99,11 @@ TweakItem("Autotsar.ATAPetyarbuiltProtectionSideItem","DisplayCategory","Mechani
 TweakItem("Autotsar.ATAPetyarbuiltProtectionSideFrontItem","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAPetyarbuiltProtectionSideTopItem","DisplayCategory","Mechanics");
 TweakItem("Base.ATSMegaTrunk","DisplayCategory","Mechanics");
+end
+
 --AutotsarMotorclub
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2778576730
+if getActivatedMods():contains("amclub") then
 TweakItem("Autotsar.ATAMotoBagBMW1","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAMotoBagBMW2","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAMotoBMWCustomMuffler","DisplayCategory","Mechanics");
@@ -92,7 +123,11 @@ TweakItem("Autotsar.ATAMotoHarleyGasTank","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAMotoHarleyHolster","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAMotoHarleySeat","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAMotoQuadSeat","DisplayCategory","Mechanics");
+end
+
 --ATA-Luton
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2792425535
+if getActivatedMods():contains("ATA_Luton") then
 TweakItem("Autotsar.ATALutonTuningMag","DisplayCategory","LitR");
 TweakItem("Autotsar.ATALutonProtectionSideFrontItem","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATALutonProtectionHoodItem","DisplayCategory","Mechanics");
@@ -100,7 +135,11 @@ TweakItem("Autotsar.ATALutonProtectionWindowFrontSideItem","DisplayCategory","Me
 TweakItem("Autotsar.ATALutonProtectionWindowFrontItem","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATALutonInteractiveTrunkRoofRackItem","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATALutonLadderItem","DisplayCategory","Mechanics");
+end
+
 --DeRumba Van
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2811232708
+if getActivatedMods():contains("ATA_VanDeRumba") then
 TweakItem("Autotsar.ATAVanDeRumbaTuningMag","DisplayCategory","LitR");
 TweakItem("Autotsar.ATAVanDeRumbaBullbar1Item","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAVanDeRumbaBullbar2Item","DisplayCategory","Mechanics");
@@ -113,12 +152,20 @@ TweakItem("Autotsar.ATAVanDeRumbaInteractiveTrunkRoofRackItem","DisplayCategory"
 TweakItem("Autotsar.ATAVanDeRumbaLadderItem","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAVanDeRumbaRoofBaseItem","DisplayCategory","Mechanics");
 TweakItem("Autotsar.ATAVanDeRumbRoofBoxItem","DisplayCategory","Mechanics");
+end
+
 --AutotsarTrailers
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2282429356
+if getActivatedMods():contains("autotsartrailers") then
 TweakItem("Base.GunRack","DisplayCategory","Mechanics");
 TweakItem("filcher.SFCarCounter","DisplayCategory","Mechanics");
 TweakItem("filcher.SFCarFridge","DisplayCategory","Mechanics");
 TweakItem("filcher.SFCarOven","DisplayCategory","Mechanics");
+end
+
 --TrueActionsDancing
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2648779556
+if getActivatedMods():contains("TrueActionsDancing") then
 TweakItem("TAD.OpenKosmotsars","DisplayCategory","FoodN");
 TweakItem("TAD.CloseKosmotsars","DisplayCategory","FoodN");
 TweakItem("TAD.BobTA_African_Noodle_Mag","DisplayCategory","LitR");
@@ -194,11 +241,20 @@ TweakItem("TAD.BobTA_Tut_One_card","DisplayCategory","Misc");
 TweakItem("TAD.BobTA_Tut_Two_card","DisplayCategory","Misc");
 TweakItem("TAD.BobTA_Wave_One_card","DisplayCategory","Misc");
 TweakItem("TAD.BobTA_Wave_Two_card","DisplayCategory","Misc");
+end
+
 --TrueMusic
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2613146550
+if getActivatedMods():contains("truemusic") then
 TweakItem("Tsarcraft.TCBoombox","DisplayCategory","Electronics");
 TweakItem("Tsarcraft.TCVinylplayer","DisplayCategory","Electronics");
+end
+
 --ZuperCart
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2478768005
+if getActivatedMods():contains("TMC_Trolley") then
 TweakItem("TMC.TrolleyContainer","DisplayCategory","Tool");
 TweakItem("TMC.TrolleyContainer2","DisplayCategory","Tool");
 TweakItem("TMC.CartContainer","DisplayCategory","Tool");
 TweakItem("TMC.CartContainer2","DisplayCategory","Tool");
+end

--- a/media/lua/client/Mod Support/VFE_Items.lua
+++ b/media/lua/client/Mod Support/VFE_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --VFE
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2667899942
+if getActivatedMods():contains("VFExpansion1") then
 TweakItem("Base.x2Scope","DisplayCategory","WepPart");
 TweakItem("Base.x4Scope","DisplayCategory","WepPart");
 TweakItem("Base.x8Scope","DisplayCategory","WepPart");
@@ -64,3 +66,4 @@ TweakItem("Base.OilFilter2","DisplayCategory","Tool");
 TweakItem("Base.9mmClip20","DisplayCategory","WepAmmoMag");
 TweakItem("Base.9mmClip17","DisplayCategory","WepAmmoMag");
 TweakItem("Base.9mmClip30","DisplayCategory","WepAmmoMag");
+end

--- a/media/lua/client/Mod Support/VacsDrinks_Items.lua
+++ b/media/lua/client/Mod Support/VacsDrinks_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --VacsDrinks
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2689863681
+if getActivatedMods():contains("VDK") then
 TweakItem("VDK.VAC_Can_Budlight","DisplayCategory","FoodB");
 TweakItem("VDK.VAC_Budlight_BeerCanEmpty","DisplayCategory","Junk");
 TweakItem("VDK.VAC_Can_Budweiser","DisplayCategory","FoodB");
@@ -56,3 +58,4 @@ TweakItem("VDK.VAC_Karhu_BeerCanEmpty","DisplayCategory","Junk");
 TweakItem("VDK.VAC_Bottle_AbsolutVodkaWaterFull","DisplayCategory","FoodB");
 TweakItem("VDK.VAC_Bottle_AbsolutVodkaFull","DisplayCategory","FoodB");
 TweakItem("VDK.VAC_Bottle_AbsolutVodkaEmpty","DisplayCategory","Junk");
+end

--- a/media/lua/client/Mod Support/VileM113APC_Items.lua
+++ b/media/lua/client/Mod Support/VileM113APC_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --VILEM113APC
+--https://steamcommunity.com/sharedfiles/filedetails/?id=1983277711
+if getActivatedMods():contains("VileM113APC") then
 TweakItem("Base.M113Tire1","DisplayCategory","Mechanics");
 TweakItem("Base.M113Tire2","DisplayCategory","Mechanics");
 TweakItem("Base.M113Tire3","DisplayCategory","Mechanics");
@@ -34,3 +36,4 @@ TweakItem("Base.M113FrontWindow3","DisplayCategory","Mechanics");
 TweakItem("Base.M113GloveBox1","DisplayCategory","Mechanics");
 TweakItem("Base.M113GloveBox2","DisplayCategory","Mechanics");
 TweakItem("Base.M113GloveBox3","DisplayCategory","Mechanics");
+end

--- a/media/lua/client/Mod Support/ZombieVirusVaccine_Items.lua
+++ b/media/lua/client/Mod Support/ZombieVirusVaccine_Items.lua
@@ -1,6 +1,8 @@
 require("ItemTweaker_Copy_CC");
 
 --ZombieVirusVaccine
+--https://steamcommunity.com/sharedfiles/filedetails/?id=2512119000
+if getActivatedMods():contains("DemoniusZombieVirusVaccine") then
 TweakItem("LabBooks.BkLaboratoryEquipment1","DisplayCategory","LitR");
 TweakItem("LabBooks.BkVirologyCourses1","DisplayCategory","LitR");
 TweakItem("LabBooks.BkChemistryCourse","DisplayCategory","LitR");
@@ -74,3 +76,4 @@ TweakItem("LabItems.FrnGolgNugget","DisplayCategory","Craft");
 TweakItem("LabItems.FrnSilverNugget","DisplayCategory","Craft");
 TweakItem("LabItems.FrnGolgIngot","DisplayCategory","Craft");
 TweakItem("LabItems.FrnSilverIngot","DisplayCategory","Craft");
+end


### PR DESCRIPTION
Added check if supported mod is active, to avoid overwriting vanilla game item categories.
> Eg.: `SoulFilchers Clearing Time` makes vanilla Corkscrew usable as a weapon and support for this mod tweaks: `TweakItem("Base.Corkscrew","DisplayCategory","WepMelee");` making no sense if mod is not active.
- Added comments with links to the mod workshop pages.


- Changed `Dylans_Items` file extension from `.txt` to `.lua`.

If accepted, the guide document should probably be updated aswell.